### PR TITLE
Dashboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,14 @@ A union of specific `…PropsOrElement` types characterizing a certain class is 
 4. Component implementation
    - Use [CSS logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) (instead of left/rigt), e.g. `marginInlineStart`.
    - Always use theme color aliases; _never_ use CSS color literals.
-   - If a slot in the component should support `Escape`, only do so for its JSX syntax style.
+   - If a slot in the component should support `Escape`, 
+     - only do so for its JSX syntax style and
+     - only outside of tightly-bound parent-child relations (e.g. `Layout` refuses to render `Escape` if it is in its `items` prop since only `LayoutItem` is allowed there).
+   - All components should export:
+     - `{componentName}Props` and `{componentName}PropsOrElement` zod schema
+     - `{ComponentName}Props` and `{ComponentName}PropsOrElement` types based on the zod schemas
+     - a `{ComponentName}` functional component (`React.FC`)
+     - a `renderIf{ComponentName}` function that renders with either props or an element (if the component has exemplars, renders any props or elements for its exact form _or its exemplars_)
 5. Recommended but unenforced code styles
    - `import` statements should occur in the following order with a line break in between:
      1. External dependencies

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Some top-level components like `View` will check the props it was provided and p
 
 ## Escaping validation
 
-These components won’t render a component that has unexpected props or content, unless you use `Escape`. If you feel the need to use a pattern not provided by this project, you can do so using the `Escape` component as a JSX element in any of a component’s content props, e.g.:
+These components won’t render a component that has unexpected props or content, unless you use `Escape`. If you feel the need to use a pattern not provided by this project, you can do so using the `Escape` component as a JSX element in any of a component’s content props that aren’t “tightly-bound”, e.g.:
 
 ```tsx
 <Section
@@ -49,7 +49,9 @@ These components won’t render a component that has unexpected props or content
 />
 ```
 
-Make sure the content you add this way conforms to [WCAG 2.1][wcag] and is designed inclusively. If you would like to share the pattern for the community, [we’d welcome your contribution][contributing]!
+A component may ignore `Escape` only if it is “tightly-bound” with another component. Components are tightly-bound when they make sense only when used together, e.g. `Layout` and `LayoutItem` where `Layout` will only render `LayoutItems` in its `items` prop. If you need to render special content in such a situation, you can either replace the entire parent with `Escape`, or use `Escape` as the _content_ of one of the children.
+
+Make sure the content you add using `Escape` conforms to [WCAG 2.1][wcag] and is designed inclusively. If you would like to share the pattern for the community, [we’d welcome your contribution][contributing]!
 
 ## Pattern structure
 

--- a/README.md
+++ b/README.md
@@ -53,27 +53,23 @@ A component may ignore `Escape` only if it is “tightly-bound” with another c
 
 Make sure the content you add using `Escape` conforms to [WCAG 2.1][wcag] and is designed inclusively. If you would like to share the pattern for the community, [we’d welcome your contribution][contributing]!
 
-## Pattern structure
+## Concepts
 
-The components in this project are usually organized by their pattern type, which is determined by shared props if relevant, otherwise by its [formatting context in normal flow][fmtctx]:
+This library harmonizes the patterns in Fluent and the UI Kit with concepts from web layout & interactivity by delivering components organized into these categories:
 
-- Components with shared props:
-  - Media, e.g.:
+- General components based on [formatting context][fmtctx]:
+  - `Block` vs `Inline`
+- Specialized clusters of components with shared interactivity considerations:
+  - **Media**, e.g.:
     - `Illustration`
     - `Chart`
-  - Inputs, e.g.:
+  - **Inputs**, e.g.:
     - `RadioGroup`
     - `ShortTextInput`
-- Components with shared formatting context:
-  - Block, e.g.:
-    - `Section`
-    - `Heading`
-  - Inline, e.g.:
-    - `Text`
-    - `Icon`
-- Special classes:
-  - Surfaces, each of which expect to be unique in a given view
-  - Views, the top-level components which validate props and render an entire UI in a viewport
+- **Surfaces**, each of which expect to be unique in a given view
+- **Views**, the top-level components which validate props and render an entire UI in a viewport
+
+Any component may also have **Exemplars**, which render the same component but with a specialized API surface optimized for a specific use-case for the pattern, e.g. `Widget` always renders a `Card` though its props are based on the more constrained scope of content for cards in a dashboard from the UI Kit. 
 
 ## Icons
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "types": "types/view.d.ts",
   "scripts": {
+    "storybook:upgrade": "yarn upgrade --scope @storybook",
     "storybook:build": "build-storybook",
     "storybook:start": "start-storybook -p 4000",
     "storybook:start-ci": "start-storybook -p 4000 --ci --quiet",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=10.0.0"
   },
   "peerDependencies": {
-    "@fluentui/react-components": "alpha",
+    "@fluentui/react-components": "beta",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
     "chart.js": "^2.9.4",
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@babel/core": "latest",
-    "@fluentui/react-components": "^9.0.0-alpha.124",
+    "@fluentui/react-components": "beta",
     "@storybook/addon-actions": "latest",
     "@storybook/addon-essentials": "latest",
     "@storybook/addon-links": "latest",

--- a/src/blocks/Card/Card.stories.mdx
+++ b/src/blocks/Card/Card.stories.mdx
@@ -95,11 +95,11 @@ used to group content as a regular Block element as well.
     args={{
       theme: 'light',
       widget: {
-        title: [{ text: fakeTitle() }],
+        title: [{ text: fakeTitle(fake) }],
         label: 'Demo Widget',
-        abstract: [{ text: fakeTitle() }],
+        abstract: [{ text: fakeTitle(fake) }],
         tabs: range(2).map((i) => ({
-          tab: { label: fakeTitle() },
+          tab: { label: fakeTitle(fake) },
           panel: [
             {
               media: {
@@ -125,7 +125,7 @@ used to group content as a regular Block element as well.
           ],
         })),
         footerAction: {
-          label: fakeTitle(),
+          label: fakeTitle(fake),
           icon: 'arrow_right',
           iconPosition: 'after',
         },

--- a/src/blocks/Card/Card.stories.mdx
+++ b/src/blocks/Card/Card.stories.mdx
@@ -1,4 +1,5 @@
 import { fake, seed } from 'faker/locale/en_US'
+import fakeTitle from '../../lib/fakeTitle'
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
 
 import { BlockCard, LayoutCard } from './StorybookCard'
@@ -80,3 +81,58 @@ used to group content as a regular Block element as well.
 </Canvas>
 
 <ArgsTable story="Card as a Layout item" />
+
+## Exemplars
+
+### Widget
+
+**Widgets** are Cards which are optimized for use in a Dashboard. They include slots for a title (optional), abstract (optional), a set of tabs (rendering just the first tab’s panel if only one tab is provided), and a call-to-action button at the end (optional).
+
+<Canvas withSource="none">
+  <Story
+    name="Widget"
+    args={{
+      theme: 'light',
+      widget: {
+        title: [{ text: fakeTitle() }],
+        label: 'Demo Widget',
+        abstract: [{ text: fakeTitle() }],
+        tabs: [
+          {
+            tab: { label: 'Main demo content' },
+            panel: [
+              {
+                media: {
+                  label: 'Demo chart',
+                  chart: {
+                    type: 'doughnut',
+                    data: {
+                      labels: ['Jan', 'Feb', 'March', 'April', 'May'],
+                      datasets: [
+                        {
+                          label: 'Laptops',
+                          data: [1860, 7700, 4100, 3012, 2930],
+                        },
+                        {
+                          label: 'Watches',
+                          data: [1200, 3600, 2480, 5049, 4596],
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        footerAction: {
+          label: fakeTitle(),
+          icon: 'arrow_right',
+          iconPosition: 'after',
+        },
+      },
+    }}
+  >
+    {seed(1234) || CardLayoutTemplate.bind({})}
+  </Story>
+</Canvas>

--- a/src/blocks/Card/Card.stories.mdx
+++ b/src/blocks/Card/Card.stories.mdx
@@ -25,6 +25,7 @@ import { themeArgType } from '../../lib'
   }}
   parameters={{
     viewMode: 'docs',
+    chromatic: { delay: 2000 },
   }}
 />
 

--- a/src/blocks/Card/Card.stories.mdx
+++ b/src/blocks/Card/Card.stories.mdx
@@ -1,3 +1,4 @@
+import range from 'lodash/range'
 import { fake, seed } from 'faker/locale/en_US'
 import fakeTitle from '../../lib/fakeTitle'
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
@@ -97,34 +98,32 @@ used to group content as a regular Block element as well.
         title: [{ text: fakeTitle() }],
         label: 'Demo Widget',
         abstract: [{ text: fakeTitle() }],
-        tabs: [
-          {
-            tab: { label: 'Main demo content' },
-            panel: [
-              {
-                media: {
-                  label: 'Demo chart',
-                  chart: {
-                    type: 'doughnut',
-                    data: {
-                      labels: ['Jan', 'Feb', 'March', 'April', 'May'],
-                      datasets: [
-                        {
-                          label: 'Laptops',
-                          data: [1860, 7700, 4100, 3012, 2930],
-                        },
-                        {
-                          label: 'Watches',
-                          data: [1200, 3600, 2480, 5049, 4596],
-                        },
-                      ],
-                    },
+        tabs: range(2).map((i) => ({
+          tab: { label: fakeTitle() },
+          panel: [
+            {
+              media: {
+                label: 'Demo chart',
+                chart: {
+                  type: ['doughnut', 'line'][i],
+                  data: {
+                    labels: ['Jan', 'Feb', 'March', 'April', 'May'],
+                    datasets: [
+                      {
+                        label: 'Laptops',
+                        data: [1860, 7700, 4100, 3012, 2930],
+                      },
+                      {
+                        label: 'Watches',
+                        data: [1200, 3600, 2480, 5049, 4596],
+                      },
+                    ],
                   },
                 },
               },
-            ],
-          },
-        ],
+            },
+          ],
+        })),
         footerAction: {
           label: fakeTitle(),
           icon: 'arrow_right',

--- a/src/blocks/Card/Card.test-stories.tsx
+++ b/src/blocks/Card/Card.test-stories.tsx
@@ -1,0 +1,48 @@
+import { Card } from './Card'
+import { CardProps } from './card-properties'
+import { Parameters } from '@storybook/addons'
+import { Paragraph } from '../Paragraph/Paragraph'
+import { Escape } from '../../lib'
+
+export default {
+  title: 'Tests/Card',
+  component: Card,
+}
+
+const CardTemplate = (props: CardProps) => <Card {...props} />
+
+export const CardJsonTest: typeof CardTemplate & {
+  args?: CardProps
+  parameters?: Parameters
+} = CardTemplate.bind({})
+
+CardJsonTest.args = {
+  card: [{ paragraph: 'eafa9885-7c39-4255-8289-06cb0f5f509f' }],
+}
+CardJsonTest.parameters = { chromatic: { disableSnapshot: true } }
+
+export const CardJsxTest: typeof CardTemplate & {
+  args?: CardProps
+  parameters?: Parameters
+} = CardTemplate.bind({})
+
+CardJsxTest.args = {
+  card: [
+    <Paragraph key="t1" paragraph="7dc865ac-d474-408f-a522-9189ce1ccbe5" />,
+  ],
+}
+CardJsxTest.parameters = { chromatic: { disableSnapshot: true } }
+
+export const CardEscapeTest: typeof CardTemplate & {
+  args?: CardProps
+  parameters?: Parameters
+} = CardTemplate.bind({})
+
+CardEscapeTest.args = {
+  card: [
+    <Escape key="t1" contentMeetsAccessibilityAndDesignStandards>
+      <span>dea8bcd5-e9d0-488e-9974-eae698606b93</span>
+    </Escape>,
+  ],
+}
+CardEscapeTest.parameters = { chromatic: { disableSnapshot: true } }

--- a/src/blocks/Card/Card.test.tsx
+++ b/src/blocks/Card/Card.test.tsx
@@ -3,5 +3,49 @@
 import expect from 'expect'
 
 describe('Card', function () {
-  it('iS READY FOR TESTS')
+  describe('interactions', function () {
+    this.timeout(5e3)
+    describe('using serializeable props', function () {
+      before(async function () {
+        await this.goto(this.storybookUrl('tests-card--card-json-test'))
+      })
+      it('renders to the page', async function () {
+        expect(
+          await this.page
+            .locator(
+              '#root div[role="group"] >> text=eafa9885-7c39-4255-8289-06cb0f5f509f'
+            )
+            .count()
+        ).toEqual(1)
+      })
+    })
+    describe('using JSX props', function () {
+      before(async function () {
+        await this.goto(this.storybookUrl('tests-card--card-jsx-test'))
+      })
+      it('renders to the page', async function () {
+        expect(
+          await this.page
+            .locator(
+              '#root div[role="group"] >> text=7dc865ac-d474-408f-a522-9189ce1ccbe5'
+            )
+            .count()
+        ).toEqual(1)
+      })
+    })
+    describe('using `Escape`', function () {
+      before(async function () {
+        await this.goto(this.storybookUrl('tests-card--card-escape-test'))
+      })
+      it('renders to the page', async function () {
+        expect(
+          await this.page
+            .locator(
+              '#root div[role="group"] >> text=dea8bcd5-e9d0-488e-9974-eae698606b93'
+            )
+            .count()
+        ).toEqual(1)
+      })
+    })
+  })
 })

--- a/src/blocks/Card/Card.tsx
+++ b/src/blocks/Card/Card.tsx
@@ -19,6 +19,7 @@ import { renderIfHeading } from '../Heading/Heading'
 import { renderIfFigure } from '../Figure/Figure'
 import { renderIfTabs } from '../Tabs/Tabs'
 import { renderIfShortInputs } from '../ShortInputs/ShortInputs'
+import { renderIfDescriptionList } from '../DescriptionList/DescriptionList'
 import { renderIfWidget, widgetPropsOrElement } from './exemplars/Widget'
 import { CardContentItemEntity, CardProps, cardProps } from './card-properties'
 
@@ -28,6 +29,7 @@ const CardContentItem = (o: CardContentItemEntity) =>
   renderIfFigure(o) ||
   renderIfTabs(o) ||
   renderIfShortInputs(o) ||
+  renderIfDescriptionList(o) ||
   renderIfEscape(o) ||
   invalidCardContentItem(o)
 

--- a/src/blocks/Card/Card.tsx
+++ b/src/blocks/Card/Card.tsx
@@ -93,6 +93,7 @@ export const Card = ({ card, contextualVariant = 'block' }: CardProps) => {
         contextualVariant === 'block' && commonStyles.centerBlock,
         contextualVariant === 'layout' && cardStyles.layoutItemCard
       )}
+      tabIndex={0}
     >
       <div className={commonStyles.elevatedSurface}>
         {Sequence<CardContentItemEntity>(card, CardContentItem, {

--- a/src/blocks/Card/Card.tsx
+++ b/src/blocks/Card/Card.tsx
@@ -35,20 +35,23 @@ const CardContentItem = (o: CardContentItemEntity) =>
 
 const useCardStyles = makeStyles({
   root: {
+    boxSizing: 'border-box',
     padding: rem(20),
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: 'transparent',
   },
   hc: (theme) => ({
     borderColor: theme.colorNeutralForeground1,
-    borderWidth: '1px',
-    borderStyle: 'solid',
   }),
   layoutItemCard: {
     minHeight: '100%',
-    boxSizing: 'border-box',
   },
   blockCard: {
     marginInlineStart: 'auto',
     marginInlineEnd: 'auto',
+    marginBlockStart: rem(20),
+    marginBlockEnd: rem(20),
   },
 })
 
@@ -62,7 +65,8 @@ export const Card = ({ card, contextualVariant = 'block' }: CardProps) => {
         cardStyles.root,
         commonStyles.elevatedSurface,
         themeName === 'high-contrast' && cardStyles.hc,
-        contextualVariant === 'block' && commonStyles.mainContentWidth,
+        contextualVariant === 'block' &&
+          commonStyles.mainContentWidthEncapsulated,
         contextualVariant === 'block' && cardStyles.blockCard,
         contextualVariant === 'layout' && cardStyles.layoutItemCard
       )}

--- a/src/blocks/Card/Card.tsx
+++ b/src/blocks/Card/Card.tsx
@@ -44,6 +44,10 @@ const useCardStyles = makeStyles({
     minHeight: '100%',
     boxSizing: 'border-box',
   },
+  blockCard: {
+    marginInlineStart: 'auto',
+    marginInlineEnd: 'auto',
+  },
 })
 
 export const Card = ({ card, contextualVariant = 'block' }: CardProps) => {
@@ -57,7 +61,7 @@ export const Card = ({ card, contextualVariant = 'block' }: CardProps) => {
         commonStyles.elevatedSurface,
         themeName === 'high-contrast' && cardStyles.hc,
         contextualVariant === 'block' && commonStyles.mainContentWidth,
-        contextualVariant === 'block' && commonStyles.centerBlock,
+        contextualVariant === 'block' && cardStyles.blockCard,
         contextualVariant === 'layout' && cardStyles.layoutItemCard
       )}
       tabIndex={0}

--- a/src/blocks/Card/Card.tsx
+++ b/src/blocks/Card/Card.tsx
@@ -3,7 +3,7 @@ import { ReactElement } from 'react'
 // todo: fix this import when Card is released directly from @fluentui/react-components
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Card as FluentCard } from '@fluentui/react-card'
-import { mergeClasses as cx } from '@fluentui/react-components'
+import { makeStyles, mergeClasses as cx } from '@fluentui/react-components'
 
 import {
   escapeElement,
@@ -43,7 +43,6 @@ export const cardProps = z
         contextualVariant: z
           .union([z.literal('block'), z.literal('layout')])
           .default('block'),
-        contextualClassName: z.string(),
       })
       .partial()
   )
@@ -57,18 +56,22 @@ const CardContentItem = (o: CardContentItemEntity) =>
   renderIfEscape(o) ||
   invalidCardContentItem(o)
 
-export const Card = ({
-  card,
-  contextualVariant = 'block',
-  contextualClassName,
-}: CardProps) => {
+const useCardStyles = makeStyles({
+  layoutItemCard: {
+    minHeight: '100%',
+    boxSizing: 'border-box',
+  },
+})
+
+export const Card = ({ card, contextualVariant = 'block' }: CardProps) => {
   const commonStyles = useCommonStyles()
+  const cardStyles = useCardStyles()
   return (
     <FluentCard
       className={cx(
         contextualVariant === 'block' && commonStyles.mainContentWidth,
         contextualVariant === 'block' && commonStyles.centerBlock,
-        contextualClassName
+        contextualVariant === 'layout' && cardStyles.layoutItemCard
       )}
     >
       <div className={commonStyles.elevatedSurface}>

--- a/src/blocks/Card/Card.tsx
+++ b/src/blocks/Card/Card.tsx
@@ -43,6 +43,7 @@ export const cardProps = z
         contextualVariant: z
           .union([z.literal('block'), z.literal('layout')])
           .default('block'),
+        contextualClassName: z.string(),
       })
       .partial()
   )
@@ -56,13 +57,18 @@ const CardContentItem = (o: CardContentItemEntity) =>
   renderIfEscape(o) ||
   invalidCardContentItem(o)
 
-export const Card = ({ card, contextualVariant = 'block' }: CardProps) => {
+export const Card = ({
+  card,
+  contextualVariant = 'block',
+  contextualClassName,
+}: CardProps) => {
   const commonStyles = useCommonStyles()
   return (
     <FluentCard
       className={cx(
         contextualVariant === 'block' && commonStyles.mainContentWidth,
-        contextualVariant === 'block' && commonStyles.centerBlock
+        contextualVariant === 'block' && commonStyles.centerBlock,
+        contextualClassName
       )}
     >
       <div className={commonStyles.elevatedSurface}>

--- a/src/blocks/Card/Card.tsx
+++ b/src/blocks/Card/Card.tsx
@@ -6,7 +6,6 @@ import { Card as FluentCard } from '@fluentui/react-card'
 import { makeStyles, mergeClasses as cx } from '@fluentui/react-components'
 
 import {
-  escapeElement,
   invalidCardContentItem,
   propsElementUnion,
   rem,
@@ -15,46 +14,13 @@ import {
   useCommonStyles,
   useFluentPatternsContext,
 } from '../../lib'
-import {
-  paragraphPropsOrElement,
-  renderIfParagraph,
-} from '../Paragraph/Paragraph'
-import { headingPropsOrElement, renderIfHeading } from '../Heading/Heading'
-import { figurePropsOrElement, renderIfFigure } from '../Figure/Figure'
-import { tabsPropsOrElement, renderIfTabs } from '../Tabs/Tabs'
-import {
-  renderIfShortInputs,
-  shortInputsPropsOrElement,
-} from '../ShortInputs/ShortInputs'
+import { renderIfParagraph } from '../Paragraph/Paragraph'
+import { renderIfHeading } from '../Heading/Heading'
+import { renderIfFigure } from '../Figure/Figure'
+import { renderIfTabs } from '../Tabs/Tabs'
+import { renderIfShortInputs } from '../ShortInputs/ShortInputs'
 import { renderIfWidget, widgetPropsOrElement } from './exemplars/Widget'
-
-export const cardContentItemEntity = z.union([
-  headingPropsOrElement,
-  paragraphPropsOrElement,
-  figurePropsOrElement,
-  tabsPropsOrElement,
-  shortInputsPropsOrElement,
-  escapeElement,
-])
-export type CardContentItemEntity = z.infer<typeof cardContentItemEntity>
-
-export const cardContentItemSequence = z.array(cardContentItemEntity)
-export type CardContentItemSequence = z.infer<typeof cardContentItemSequence>
-
-export const cardProps = z
-  .object({
-    card: cardContentItemSequence,
-  })
-  .merge(
-    z
-      .object({
-        contextualVariant: z
-          .union([z.literal('block'), z.literal('layout')])
-          .default('block'),
-      })
-      .partial()
-  )
-export type CardProps = z.infer<typeof cardProps>
+import { CardContentItemEntity, CardProps, cardProps } from './card-properties'
 
 const CardContentItem = (o: CardContentItemEntity) =>
   renderIfHeading(o) ||
@@ -88,6 +54,7 @@ export const Card = ({ card, contextualVariant = 'block' }: CardProps) => {
     <FluentCard
       className={cx(
         cardStyles.root,
+        commonStyles.elevatedSurface,
         themeName === 'high-contrast' && cardStyles.hc,
         contextualVariant === 'block' && commonStyles.mainContentWidth,
         contextualVariant === 'block' && commonStyles.centerBlock,
@@ -95,11 +62,9 @@ export const Card = ({ card, contextualVariant = 'block' }: CardProps) => {
       )}
       tabIndex={0}
     >
-      <div className={commonStyles.elevatedSurface}>
-        {Sequence<CardContentItemEntity>(card, CardContentItem, {
-          contextualVariant: 'card',
-        })}
-      </div>
+      {Sequence<CardContentItemEntity>(card, CardContentItem, {
+        contextualVariant: 'card',
+      })}
     </FluentCard>
   )
 }

--- a/src/blocks/Card/StorybookCard.tsx
+++ b/src/blocks/Card/StorybookCard.tsx
@@ -1,5 +1,8 @@
-import { Main } from '../../surfaces'
+import range from 'lodash/range'
+
 import { FluentPatternsProvider, ThemeName } from '../../lib'
+
+import { Main } from '../../surfaces'
 import { CardProps } from './Card'
 
 export const BlockCard = ({
@@ -21,7 +24,7 @@ export const LayoutCard = ({
         {
           layout: {
             variant: 'grid',
-            items: [props, { ...props }, { ...props }, { ...props }],
+            items: range(3).map((i) => ({ item: { ...props } })),
           },
         },
       ]}

--- a/src/blocks/Card/StorybookCard.tsx
+++ b/src/blocks/Card/StorybookCard.tsx
@@ -3,7 +3,7 @@ import range from 'lodash/range'
 import { FluentPatternsProvider, ThemeName } from '../../lib'
 
 import { Main } from '../../surfaces'
-import { CardProps } from './Card'
+import { CardProps } from './card-properties'
 
 export const BlockCard = ({
   theme,

--- a/src/blocks/Card/card-properties.ts
+++ b/src/blocks/Card/card-properties.ts
@@ -4,6 +4,7 @@ import { paragraphPropsOrElement } from '../Paragraph/Paragraph'
 import { figurePropsOrElement } from '../Figure/Figure'
 import { tabsPropsOrElement } from '../Tabs/Tabs'
 import { shortInputsPropsOrElement } from '../ShortInputs/ShortInputs'
+import { descriptionListPropsOrElement } from '../DescriptionList/DescriptionList'
 import { escapeElement } from '../../lib'
 
 export const cardContentItemEntity = z.union([
@@ -12,6 +13,7 @@ export const cardContentItemEntity = z.union([
   figurePropsOrElement,
   tabsPropsOrElement,
   shortInputsPropsOrElement,
+  descriptionListPropsOrElement,
   escapeElement,
 ])
 export type CardContentItemEntity = z.infer<typeof cardContentItemEntity>

--- a/src/blocks/Card/card-properties.ts
+++ b/src/blocks/Card/card-properties.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+import { headingPropsOrElement } from '../Heading/Heading'
+import { paragraphPropsOrElement } from '../Paragraph/Paragraph'
+import { figurePropsOrElement } from '../Figure/Figure'
+import { tabsPropsOrElement } from '../Tabs/Tabs'
+import { shortInputsPropsOrElement } from '../ShortInputs/ShortInputs'
+import { escapeElement } from '../../lib'
+
+export const cardContentItemEntity = z.union([
+  headingPropsOrElement,
+  paragraphPropsOrElement,
+  figurePropsOrElement,
+  tabsPropsOrElement,
+  shortInputsPropsOrElement,
+  escapeElement,
+])
+export type CardContentItemEntity = z.infer<typeof cardContentItemEntity>
+
+export const cardContentItemSequence = z.array(cardContentItemEntity)
+export type CardContentItemSequence = z.infer<typeof cardContentItemSequence>
+
+export const cardContextualVariants = z
+  .object({
+    contextualVariant: z
+      .union([z.literal('block'), z.literal('layout')])
+      .default('block'),
+  })
+  .partial()
+
+export const cardProps = z
+  .object({
+    card: cardContentItemSequence,
+  })
+  .merge(cardContextualVariants)
+export type CardProps = z.infer<typeof cardProps>

--- a/src/blocks/Card/exemplars/Widget.tsx
+++ b/src/blocks/Card/exemplars/Widget.tsx
@@ -1,26 +1,31 @@
 import { z } from 'zod'
-import { inlineSequenceOrString } from '../../../inlines'
-import { tabsProps } from '../../Tabs/Tabs'
-import { buttonProps } from '../../../inputs'
-import { Card, CardProps } from '../Card'
 import { ReactElement } from 'react'
-import { propsElementUnion } from '../../../lib'
 
-export const widgetProps = z.object({
-  widget: tabsProps.omit({ tabVariant: true, tabListVariant: true }).merge(
-    z.object({
-      title: inlineSequenceOrString.optional(),
-      abstract: inlineSequenceOrString.optional(),
-      footerAction: buttonProps
-        .omit({
-          type: true,
-          variant: true,
-          iconOnly: true,
-        })
-        .optional(),
-    })
-  ),
-})
+import { inlineSequenceOrString } from '../../../inlines'
+import { propsElementUnion } from '../../../lib'
+import { buttonProps } from '../../../inputs'
+
+import { tabsProps } from '../../Tabs/Tabs'
+import { Card } from '../Card'
+import { cardContextualVariants, CardProps } from '../card-properties'
+
+export const widgetProps = z
+  .object({
+    widget: tabsProps.omit({ tabVariant: true, tabListVariant: true }).merge(
+      z.object({
+        title: inlineSequenceOrString.optional(),
+        abstract: inlineSequenceOrString.optional(),
+        footerAction: buttonProps
+          .omit({
+            type: true,
+            variant: true,
+            iconOnly: true,
+          })
+          .optional(),
+      })
+    ),
+  })
+  .merge(cardContextualVariants)
 export type WidgetProps = z.infer<typeof widgetProps>
 
 const widgetFooterActionProps = {
@@ -30,6 +35,7 @@ const widgetFooterActionProps = {
 
 export const widgetCard = ({
   widget: { title, abstract, label, tabs, footerAction },
+  contextualVariant,
 }: WidgetProps): CardProps => ({
   card: [
     ...(title ? [{ paragraph: title, level: 3 }] : []),
@@ -39,6 +45,7 @@ export const widgetCard = ({
       ? [{ inputs: [{ ...footerAction, ...widgetFooterActionProps }] }]
       : []),
   ],
+  contextualVariant,
 })
 
 export const Widget = (props: WidgetProps) => <Card {...widgetCard(props)} />

--- a/src/blocks/Card/exemplars/Widget.tsx
+++ b/src/blocks/Card/exemplars/Widget.tsx
@@ -1,0 +1,64 @@
+import { z } from 'zod'
+import { inlineSequenceOrString } from '../../../inlines'
+import { tabsProps } from '../../Tabs/Tabs'
+import { buttonProps } from '../../../inputs'
+import { Card, CardProps } from '../Card'
+import { ReactElement } from 'react'
+import { propsElementUnion } from '../../../lib'
+
+export const widgetProps = z.object({
+  widget: tabsProps.omit({ tabVariant: true, tabListVariant: true }).merge(
+    z.object({
+      title: inlineSequenceOrString.optional(),
+      abstract: inlineSequenceOrString.optional(),
+      footerAction: buttonProps
+        .omit({
+          type: true,
+          variant: true,
+          iconOnly: true,
+        })
+        .optional(),
+    })
+  ),
+})
+export type WidgetProps = z.infer<typeof widgetProps>
+
+const widgetFooterActionProps = {
+  type: 'button' as 'button',
+  variant: 'transparent' as 'transparent',
+}
+
+export const widgetCard = ({
+  widget: { title, abstract, label, tabs, footerAction },
+}: WidgetProps): CardProps => ({
+  card: [
+    ...(title ? [{ paragraph: title, level: 3 }] : []),
+    ...(abstract ? [{ paragraph: abstract }] : []),
+    ...(tabs ? (tabs.length > 1 ? [{ tabs, label }] : tabs[0].panel) : []),
+    ...(footerAction
+      ? [{ inputs: [{ ...footerAction, ...widgetFooterActionProps }] }]
+      : []),
+  ],
+})
+
+export const Widget = (props: WidgetProps) => <Card {...widgetCard(props)} />
+
+function isWidgetProps(o: any): o is WidgetProps {
+  return 'widget' in o
+}
+
+function isWidgetElement(
+  o: any
+): o is ReactElement<WidgetProps, typeof Widget> {
+  return o?.type === Widget
+}
+
+export const widgetPropsOrElement = propsElementUnion<
+  typeof widgetProps,
+  typeof Widget
+>(widgetProps)
+export type WidgetPropsOrElement = z.infer<typeof widgetPropsOrElement>
+
+export function renderIfWidget(o: any) {
+  return isWidgetProps(o) ? <Widget {...o} /> : isWidgetElement(o) ? o : null
+}

--- a/src/blocks/DescriptionList/DescriptionList.stories.mdx
+++ b/src/blocks/DescriptionList/DescriptionList.stories.mdx
@@ -41,7 +41,7 @@ used to present a set of summary statistics.
     args={{
       theme: 'light',
       descriptionList: range(4).map((i) => ({
-        title: fakeTitle(),
+        title: fakeTitle(fake),
         description: Math.ceil(Math.pow(Math.PI, i)) + '%',
       })),
     }}

--- a/src/blocks/DescriptionList/DescriptionList.stories.mdx
+++ b/src/blocks/DescriptionList/DescriptionList.stories.mdx
@@ -1,0 +1,53 @@
+import range from 'lodash/range'
+import { fake, seed } from 'faker/locale/en_US'
+import fakeTitle from '../../lib/fakeTitle'
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
+
+import { DescriptionList } from './StorybookDescriptionList'
+import { themeArgType } from '../../lib'
+
+<Meta
+  title="Blocks/Description list"
+  component={DescriptionList}
+  argTypes={{
+    ...themeArgType,
+    descriptionList: {
+      name: 'Description list',
+      control: {
+        type: 'object',
+      },
+      table: {
+        type: {
+          summary: 'DescriptionListProps',
+        },
+      },
+    },
+  }}
+  parameters={{
+    viewMode: 'docs',
+  }}
+/>
+
+export const DescriptionListTemplate = (props) => <DescriptionList {...props} />
+
+# Description list
+
+Description lists are used to present a series of titled descriptions, often
+used to present a set of summary statistics.
+
+<Canvas withSource="none">
+  <Story
+    name="Description list"
+    args={{
+      theme: 'light',
+      descriptionList: range(4).map((i) => ({
+        title: fakeTitle(),
+        description: Math.ceil(Math.pow(Math.PI, i)) + '%',
+      })),
+    }}
+  >
+    {seed(1234) || DescriptionListTemplate.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Description list" />

--- a/src/blocks/DescriptionList/DescriptionList.test-stories.tsx
+++ b/src/blocks/DescriptionList/DescriptionList.test-stories.tsx
@@ -1,0 +1,26 @@
+import { DescriptionList, DescriptionListProps } from './DescriptionList'
+import { Parameters } from '@storybook/addons'
+
+export default {
+  title: 'Tests/Dl',
+  component: DescriptionList,
+}
+
+const DescriptionListTemplate = (props: DescriptionListProps) => (
+  <DescriptionList {...props} />
+)
+
+export const DlJsonTest: typeof DescriptionListTemplate & {
+  args?: DescriptionListProps
+  parameters?: Parameters
+} = DescriptionListTemplate.bind({})
+
+DlJsonTest.args = {
+  descriptionList: [
+    {
+      title: '84f20521-7e72-4c2a-8782-f931709653c3',
+      description: '3c15cfbd-1fc0-4b6d-8334-59f94e5b4886',
+    },
+  ],
+}
+DlJsonTest.parameters = { chromatic: { disableSnapshot: true } }

--- a/src/blocks/DescriptionList/DescriptionList.test.tsx
+++ b/src/blocks/DescriptionList/DescriptionList.test.tsx
@@ -1,0 +1,28 @@
+/* eslint func-names: 0 */
+
+import expect from 'expect'
+
+describe('Description list', function () {
+  describe('interactions', function () {
+    this.timeout(5e3)
+    describe('using serializeable props', function () {
+      before(async function () {
+        await this.goto(this.storybookUrl('tests-dl--dl-json-test'))
+      })
+      it('renders to the page', async function () {
+        expect(
+          await this.page
+            .locator('#root dl dt >> text=84f20521-7e72-4c2a-8782-f931709653c3')
+            .count()
+        ).toEqual(1)
+        expect(
+          await this.page
+            .locator('#root dl dd >> text=3c15cfbd-1fc0-4b6d-8334-59f94e5b4886')
+            .count()
+        ).toEqual(1)
+        expect(await this.page.locator('#root dl dt + dd').count()).toEqual(1)
+        expect(await this.page.locator('#root dl dd + dt').count()).toEqual(0)
+      })
+    })
+  })
+})

--- a/src/blocks/DescriptionList/DescriptionList.tsx
+++ b/src/blocks/DescriptionList/DescriptionList.tsx
@@ -2,21 +2,20 @@ import { z } from 'zod'
 import { InlineContent, inlineSequenceOrString } from '../../inlines'
 import { makeStyles, mergeClasses as cx } from '@fluentui/react-components'
 import {
+  key,
   propsElementUnion,
-  Sequence,
   useCommonStyles,
   useTextBlockStyles,
 } from '../../lib'
 import { ReactElement } from 'react'
 
-const descriptionListItemProps = z.object({
-  title: inlineSequenceOrString,
-  description: inlineSequenceOrString,
-})
-type DescriptionListItemProps = z.infer<typeof descriptionListItemProps>
-
 export const descriptionListProps = z.object({
-  descriptionList: z.array(descriptionListItemProps),
+  descriptionList: z.array(
+    z.object({
+      title: inlineSequenceOrString,
+      description: inlineSequenceOrString,
+    })
+  ),
 })
 export type DescriptionListProps = z.infer<typeof descriptionListProps>
 
@@ -40,26 +39,10 @@ const useDescriptionListStyles = makeStyles({
   },
 })
 
-const DescriptionListItem = ({
-  title,
-  description,
-}: DescriptionListItemProps) => {
-  const descriptionListStyles = useDescriptionListStyles()
-  return (
-    <div className={descriptionListStyles.listItem}>
-      <dt className={descriptionListStyles.itemTitle}>
-        <InlineContent inlines={title} />
-      </dt>
-      <dd className={descriptionListStyles.itemDescription}>
-        <InlineContent inlines={description} />
-      </dd>
-    </div>
-  )
-}
-
 export const DescriptionList = ({ descriptionList }: DescriptionListProps) => {
   const commonStyles = useCommonStyles()
   const textBlockStyles = useTextBlockStyles()
+  const descriptionListStyles = useDescriptionListStyles()
   return (
     <dl
       className={cx(
@@ -68,7 +51,16 @@ export const DescriptionList = ({ descriptionList }: DescriptionListProps) => {
         textBlockStyles.root
       )}
     >
-      {Sequence<DescriptionListItemProps>(descriptionList, DescriptionListItem)}
+      {descriptionList.map((item) => (
+        <div key={key(item)} className={descriptionListStyles.listItem}>
+          <dt className={descriptionListStyles.itemTitle}>
+            <InlineContent inlines={item.title} />
+          </dt>
+          <dd className={descriptionListStyles.itemDescription}>
+            <InlineContent inlines={item.description} />
+          </dd>
+        </div>
+      ))}
     </dl>
   )
 }

--- a/src/blocks/DescriptionList/DescriptionList.tsx
+++ b/src/blocks/DescriptionList/DescriptionList.tsx
@@ -1,0 +1,98 @@
+import { z } from 'zod'
+import { InlineContent, inlineSequenceOrString } from '../../inlines'
+import { makeStyles, mergeClasses as cx } from '@fluentui/react-components'
+import {
+  propsElementUnion,
+  Sequence,
+  useCommonStyles,
+  useTextBlockStyles,
+} from '../../lib'
+import { ReactElement } from 'react'
+
+const descriptionListItemProps = z.object({
+  title: inlineSequenceOrString,
+  description: inlineSequenceOrString,
+})
+type DescriptionListItemProps = z.infer<typeof descriptionListItemProps>
+
+export const descriptionListProps = z.object({
+  descriptionList: z.array(descriptionListItemProps),
+})
+export type DescriptionListProps = z.infer<typeof descriptionListProps>
+
+const useDescriptionListStyles = makeStyles({
+  listItem: {
+    display: 'flex',
+    flexFlow: 'column nowrap',
+    marginBlockEnd: '1.5rem',
+    '&:last-child': { marginBlockEnd: 0 },
+  },
+  itemTitle: {
+    order: 1,
+    fontSize: '.75rem',
+    lineHeight: 4 / 3,
+  },
+  itemDescription: {
+    order: 0,
+    fontSize: '1.5rem',
+    lineHeight: 4 / 3,
+    marginLeft: 0,
+  },
+})
+
+const DescriptionListItem = ({
+  title,
+  description,
+}: DescriptionListItemProps) => {
+  const descriptionListStyles = useDescriptionListStyles()
+  return (
+    <div className={descriptionListStyles.listItem}>
+      <dt className={descriptionListStyles.itemTitle}>
+        <InlineContent inlines={title} />
+      </dt>
+      <dd className={descriptionListStyles.itemDescription}>
+        <InlineContent inlines={description} />
+      </dd>
+    </div>
+  )
+}
+
+export const DescriptionList = ({ descriptionList }: DescriptionListProps) => {
+  const commonStyles = useCommonStyles()
+  const textBlockStyles = useTextBlockStyles()
+  return (
+    <dl
+      className={cx(
+        commonStyles.mainContentWidth,
+        commonStyles.centerBlock,
+        textBlockStyles.root
+      )}
+    >
+      {Sequence<DescriptionListItemProps>(descriptionList, DescriptionListItem)}
+    </dl>
+  )
+}
+
+function isDescriptionListProps(o: any): o is DescriptionListProps {
+  return 'descriptionList' in o
+}
+
+function isDescriptionListElement(
+  o: any
+): o is ReactElement<DescriptionListProps, typeof DescriptionList> {
+  return o?.type === DescriptionList
+}
+
+export const descriptionListPropsOrElement = propsElementUnion<
+  typeof descriptionListProps,
+  typeof DescriptionList
+>(descriptionListProps)
+export type DescriptionListPropsOrElement = z.infer<typeof descriptionListProps>
+
+export function renderIfDescriptionList(o: any) {
+  return isDescriptionListProps(o) ? (
+    <DescriptionList {...o} />
+  ) : isDescriptionListElement(o) ? (
+    o
+  ) : null
+}

--- a/src/blocks/DescriptionList/StorybookDescriptionList.tsx
+++ b/src/blocks/DescriptionList/StorybookDescriptionList.tsx
@@ -1,0 +1,24 @@
+import { FluentPatternsProvider, ThemeName } from '../../lib'
+
+import { Main } from '../../surfaces'
+import { DescriptionListProps } from './DescriptionList'
+
+export const DescriptionList = ({
+  theme,
+  ...props
+}: DescriptionListProps & { theme: ThemeName }) => (
+  <FluentPatternsProvider themeName={theme}>
+    <Main
+      blocks={[
+        {
+          card: [
+            {
+              ...props,
+            },
+          ],
+        },
+      ]}
+      title={[{ text: ' ' }]}
+    />
+  </FluentPatternsProvider>
+)

--- a/src/blocks/Figure/Figure.test-stories.tsx
+++ b/src/blocks/Figure/Figure.test-stories.tsx
@@ -1,0 +1,25 @@
+import { Figure, FigureProps } from './Figure'
+import { Parameters } from '@storybook/addons'
+
+export default {
+  title: 'Tests/Figure',
+  component: Figure,
+}
+
+const FigureTemplate = (props: FigureProps) => <Figure {...props} />
+
+export const FigureJsonTest: typeof FigureTemplate & {
+  args?: FigureProps
+  parameters?: Parameters
+} = FigureTemplate.bind({})
+
+FigureJsonTest.args = {
+  media: {
+    light: 'https://i.ibb.co/LdW9rHH/deploy.png',
+    dark: 'https://i.ibb.co/LdW9rHH/deploy.png',
+    'high-contrast': 'https://i.ibb.co/LdW9rHH/deploy.png',
+    label: '0c9c1a2c-f75c-4a03-a2eb-a84a097ea33d',
+  },
+  caption: '56fe5be3-ad5a-481e-b971-cab910f1c99b',
+}
+FigureJsonTest.parameters = { chromatic: { disableSnapshot: true } }

--- a/src/blocks/Figure/Figure.test.tsx
+++ b/src/blocks/Figure/Figure.test.tsx
@@ -3,5 +3,28 @@
 import expect from 'expect'
 
 describe('Figure', function () {
-  it('iS READY FOR TESTS')
+  describe('interactions', function () {
+    this.timeout(5e3)
+    describe('using serializeable props', function () {
+      before(async function () {
+        await this.goto(this.storybookUrl('tests-figure--figure-json-test'))
+      })
+      it('renders to the page', async function () {
+        expect(
+          await this.page
+            .locator(
+              '#root figure img[alt="0c9c1a2c-f75c-4a03-a2eb-a84a097ea33d"]'
+            )
+            .count()
+        ).toEqual(1)
+        expect(
+          await this.page
+            .locator(
+              '#root figcaption >> text=56fe5be3-ad5a-481e-b971-cab910f1c99b'
+            )
+            .count()
+        ).toEqual(1)
+      })
+    })
+  })
 })

--- a/src/blocks/Layout/Layout.stories.mdx
+++ b/src/blocks/Layout/Layout.stories.mdx
@@ -46,10 +46,12 @@ The `Layout` component is a block which can arrange its content items such that 
     args={{
       theme: 'light',
       variant: 'grid',
-      items: range(7).map(() => ({
-        card: [{ paragraph: [{ text: fake('{{lorem.sentence}}') }] }],
+      items: range(7).map((i) => ({
+        item: {
+          card: [{ paragraph: [{ text: fake('{{lorem.sentence}}') }] }],
+        },
+        ...(i === 0 && { inlineSizeFactor: 2 }),
       })),
-      itemOptions: [{ inlineSizeFactor: 2 }],
     }}
   >
     {seed(1234) || LayoutTemplate.bind({})}

--- a/src/blocks/Layout/Layout.stories.mdx
+++ b/src/blocks/Layout/Layout.stories.mdx
@@ -1,5 +1,6 @@
 import range from 'lodash/range'
 import { fake, seed } from 'faker/locale/en_US'
+import fakeTitle from '../../lib/fakeTitle'
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
 
 import { Layout } from './StorybookLayout'
@@ -10,21 +11,23 @@ import { themeArgType } from '../../lib'
   component={Layout}
   argTypes={{
     ...themeArgType,
-    variant: {
-      name: 'variant',
-      abstract: 'Which layout strategy to use.',
-      control: {
-        type: 'inline-radio',
-        labels: { grid: 'Grid', flex: 'Flexbox' },
-      },
-    },
-    items: {
-      name: 'Items',
-      abstract: 'The items to arrange.',
+    layout: {
+      name: 'Layout',
+      abstract: 'The layout configuration.',
       control: { type: 'object' },
       table: {
         type: {
-          summary: 'LayoutItemSequence',
+          summary: 'LayoutProps',
+        },
+      },
+    },
+    dashboard: {
+      name: 'Dashboard',
+      abstract: 'The dashboard alternative API surface for Layout.',
+      control: { type: 'object' },
+      table: {
+        type: {
+          summary: 'DashboardProps',
         },
       },
     },
@@ -45,13 +48,15 @@ The `Layout` component is a block which can arrange its content items such that 
     name="Layout"
     args={{
       theme: 'light',
-      variant: 'grid',
-      items: range(7).map((i) => ({
-        item: {
-          card: [{ paragraph: [{ text: fake('{{lorem.sentence}}') }] }],
-        },
-        ...(i === 0 && { inlineSizeFactor: 2, blockSizeFactor: 2 }),
-      })),
+      layout: {
+        variant: 'grid',
+        items: range(7).map((i) => ({
+          item: {
+            card: [{ paragraph: [{ text: fake('{{lorem.sentence}}') }] }],
+          },
+          ...(i === 0 && { inlineSizeFactor: 2, blockSizeFactor: 2 }),
+        })),
+      },
     }}
   >
     {seed(1234) || LayoutTemplate.bind({})}
@@ -59,3 +64,94 @@ The `Layout` component is a block which can arrange its content items such that 
 </Canvas>
 
 <ArgsTable story="Layout" />
+
+## Exemplars
+
+### Dashboard
+
+**Dashboards** are grid-variant Layouts that expect Widgets (an exemplar of Card) as their items.
+
+<Canvas withSource="none">
+  <Story
+    name="Dashboard"
+    args={{
+      theme: 'light',
+      dashboard: {
+        items: [
+          ...range(5).map((i) => ({
+            item: {
+              widget: {
+                title: [{ text: fakeTitle(fake) }],
+                label: 'Demo Widget',
+                abstract: [{ text: fakeTitle(fake) }],
+                tabs: range(2).map((j) => ({
+                  tab: { label: fakeTitle(fake) },
+                  panel: [
+                    {
+                      media: {
+                        label: 'Demo chart',
+                        chart: {
+                          type: ['line', 'doughnut'][i === 0 ? 1 : j],
+                          data: {
+                            labels: ['Jan', 'Feb', 'March', 'April', 'May'],
+                            datasets: [
+                              {
+                                label: 'Laptops',
+                                data: [1860, 7700, 4100, 3012, 2930],
+                              },
+                              {
+                                label: 'Watches',
+                                data: [1200, 3600, 2480, 5049, 4596],
+                              },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  ],
+                })),
+                footerAction: {
+                  label: fakeTitle(fake),
+                  icon: 'arrow_right',
+                  iconPosition: 'after',
+                },
+              },
+            },
+            ...(i === 0 && { inlineSizeFactor: 2, blockSizeFactor: 2 }),
+          })),
+          {
+            item: {
+              widget: {
+                title: [{ text: fakeTitle(fake) }],
+                label: 'Demo Widget',
+                abstract: [{ text: fakeTitle(fake) }],
+                tabs: [
+                  {
+                    tab: { label: fakeTitle(fake) },
+                    panel: [
+                      {
+                        descriptionList: range(4).map((i) => ({
+                          title: fakeTitle(fake),
+                          description: Math.floor(Math.pow(Math.PI, i)) + '%',
+                        })),
+                      },
+                    ],
+                  },
+                ],
+                footerAction: {
+                  label: fakeTitle(fake),
+                  icon: 'arrow_right',
+                  iconPosition: 'after',
+                },
+              },
+            },
+          },
+        ],
+      },
+    }}
+  >
+    {seed(1234) || LayoutTemplate.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Dashboard" />

--- a/src/blocks/Layout/Layout.stories.mdx
+++ b/src/blocks/Layout/Layout.stories.mdx
@@ -50,7 +50,7 @@ The `Layout` component is a block which can arrange its content items such that 
         item: {
           card: [{ paragraph: [{ text: fake('{{lorem.sentence}}') }] }],
         },
-        ...(i === 0 && { inlineSizeFactor: 2 }),
+        ...(i === 0 && { inlineSizeFactor: 2, blockSizeFactor: 2 }),
       })),
     }}
   >

--- a/src/blocks/Layout/Layout.stories.mdx
+++ b/src/blocks/Layout/Layout.stories.mdx
@@ -34,6 +34,7 @@ import { themeArgType } from '../../lib'
   }}
   parameters={{
     viewMode: 'docs',
+    chromatic: { delay: 2000 },
   }}
 />
 

--- a/src/blocks/Layout/Layout.stories.mdx
+++ b/src/blocks/Layout/Layout.stories.mdx
@@ -49,6 +49,7 @@ The `Layout` component is a block which can arrange its content items such that 
       items: range(7).map(() => ({
         card: [{ paragraph: [{ text: fake('{{lorem.sentence}}') }] }],
       })),
+      itemOptions: [{ inlineSizeFactor: 2 }],
     }}
   >
     {seed(1234) || LayoutTemplate.bind({})}

--- a/src/blocks/Layout/Layout.test-stories.tsx
+++ b/src/blocks/Layout/Layout.test-stories.tsx
@@ -1,0 +1,29 @@
+import { Layout } from './Layout'
+import { LayoutProps } from './layout-properties'
+import { Parameters } from '@storybook/addons'
+import { Paragraph } from '../Paragraph/Paragraph'
+import { Escape } from '../../lib'
+
+export default {
+  title: 'Tests/Layout',
+  component: Layout,
+}
+
+const LayoutTemplate = (props: LayoutProps) => <Layout {...props} />
+
+export const LayoutJsonTest: typeof LayoutTemplate & {
+  args?: LayoutProps
+  parameters?: Parameters
+} = LayoutTemplate.bind({})
+
+LayoutJsonTest.args = {
+  layout: {
+    variant: 'grid',
+    items: [
+      {
+        item: { card: [{ paragraph: '7ff644a3-eb27-4e97-8978-5d7b3d569388' }] },
+      },
+    ],
+  },
+}
+LayoutJsonTest.parameters = { chromatic: { disableSnapshot: true } }

--- a/src/blocks/Layout/Layout.test.tsx
+++ b/src/blocks/Layout/Layout.test.tsx
@@ -2,6 +2,6 @@
 
 import expect from 'expect'
 
-describe('Figure', function () {
+describe('Layout', function () {
   it('iS READY FOR TESTS')
 })

--- a/src/blocks/Layout/Layout.test.tsx
+++ b/src/blocks/Layout/Layout.test.tsx
@@ -3,5 +3,21 @@
 import expect from 'expect'
 
 describe('Layout', function () {
-  it('iS READY FOR TESTS')
+  describe('interactions', function () {
+    this.timeout(5e3)
+    describe('using serializeable props', function () {
+      before(async function () {
+        await this.goto(this.storybookUrl('tests-layout--layout-json-test'))
+      })
+      it('renders to the page', async function () {
+        expect(
+          await this.page
+            .locator(
+              '#root [role=group] >> text=7ff644a3-eb27-4e97-8978-5d7b3d569388'
+            )
+            .count()
+        ).toEqual(1)
+      })
+    })
+  })
 })

--- a/src/blocks/Layout/Layout.tsx
+++ b/src/blocks/Layout/Layout.tsx
@@ -1,38 +1,21 @@
 import { z } from 'zod'
 import { ReactElement } from 'react'
-import get from 'lodash/get'
 import { makeStyles, mergeClasses as cx } from '@fluentui/react-components'
 
+import { propsElementUnion, Sequence } from '../../lib'
+
 import {
-  escapeElement,
-  invalidLayoutItem,
-  propsElementUnion,
-  renderIfEscape,
-  Sequence,
-} from '../../lib'
-import { cardPropsOrElement, renderIfCard } from '../Card/Card'
+  LayoutItemPropsOrElement,
+  layoutItemPropsOrElement,
+  renderIfLayoutItem,
+} from './LayoutItem'
 
-export const layoutItemEntity = z.union([cardPropsOrElement, escapeElement])
-export type LayoutItemEntity = z.infer<typeof layoutItemEntity>
-
-export const layoutItemSequence = z.array(layoutItemEntity)
-
-export const layoutItemOptionProps = z.union([
-  z.object({
-    inlineSizeFactor: z.number().int().gte(1).lte(2).default(1).optional(),
-  }),
-  z.undefined(),
-])
-export type LayoutItemOptionProps = z.infer<typeof layoutItemOptionProps>
-
-export const layoutVariant = z.union([z.literal('grid'), z.literal('flex')])
-export type LayoutVariant = z.infer<typeof layoutVariant>
+import { layoutVariant } from './layout-types'
 
 export const layoutProps = z.object({
   layout: z.object({
     variant: layoutVariant,
-    items: layoutItemSequence,
-    itemOptions: z.array(layoutItemOptionProps).optional(),
+    items: z.array(layoutItemPropsOrElement),
   }),
 })
 export type LayoutProps = z.infer<typeof layoutProps>
@@ -56,53 +39,18 @@ const useLayoutStyles = makeStyles({
     marginInlineEnd: '-.5rem',
     marginBlockEnd: '-.5rem',
   },
-  flexItemSizeFactor1: {
-    flex: '1 0 auto',
-    marginInlineEnd: '.5rem',
-    marginBlockEnd: '.5rem',
-  },
-  flexItemSizeFactor2: {
-    flex: '2 0 auto',
-    marginInlineEnd: '.5rem',
-    marginBlockEnd: '.5rem',
-  },
-  gridItemSizeFactor1: {},
-  gridItemSizeFactor2: {
-    '@media screen and (min-width: 600px)': {
-      gridColumnEnd: 'span 2',
-    },
-  },
 })
 
-export const LayoutItem = (o: LayoutItemEntity) =>
-  renderIfCard(o) || renderIfEscape(o) || invalidLayoutItem(o)
-
-export const Layout = ({
-  layout: { variant, items, itemOptions },
-}: LayoutProps) => {
+export const Layout = ({ layout: { variant, items } }: LayoutProps) => {
   const styles = useLayoutStyles()
-
-  const sequenceItemProps = items.map((_, i) => ({
-    contextualClassName:
-      styles[
-        `${variant}ItemSizeFactor${
-          get(itemOptions, [i, 'inlineSizeFactor'], 1) as '1' | '2'
-        }`
-      ],
-  }))
 
   return (
     <section className={cx(styles.root, styles[variant])}>
       {
         <>
-          {Sequence<LayoutItemEntity>(
-            items,
-            LayoutItem,
-            {
-              contextualVariant: 'layout',
-            },
-            sequenceItemProps
-          )}
+          {Sequence<LayoutItemPropsOrElement>(items, renderIfLayoutItem, {
+            contextualVariant: variant,
+          })}
         </>
       }
     </section>

--- a/src/blocks/Layout/Layout.tsx
+++ b/src/blocks/Layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { ReactElement } from 'react'
+import get from 'lodash/get'
 import { makeStyles, mergeClasses as cx } from '@fluentui/react-components'
 
 import {
@@ -16,10 +17,22 @@ export type LayoutItemEntity = z.infer<typeof layoutItemEntity>
 
 export const layoutItemSequence = z.array(layoutItemEntity)
 
+export const layoutItemOptionProps = z.union([
+  z.object({
+    inlineSizeFactor: z.number().int().gte(1).lte(2).default(1).optional(),
+  }),
+  z.undefined(),
+])
+export type LayoutItemOptionProps = z.infer<typeof layoutItemOptionProps>
+
+export const layoutVariant = z.union([z.literal('grid'), z.literal('flex')])
+export type LayoutVariant = z.infer<typeof layoutVariant>
+
 export const layoutProps = z.object({
   layout: z.object({
-    variant: z.union([z.literal('grid'), z.literal('flex')]),
+    variant: layoutVariant,
     items: layoutItemSequence,
+    itemOptions: z.array(layoutItemOptionProps).optional(),
   }),
 })
 export type LayoutProps = z.infer<typeof layoutProps>
@@ -31,18 +44,32 @@ const useLayoutStyles = makeStyles({
   },
   grid: {
     display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+    gridTemplateColumns: '1fr',
     gap: '.5rem',
+    '@media screen and (min-width: 600px)': {
+      gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+    },
   },
   flex: {
     display: 'flex',
     flexFlow: 'row wrap',
     marginInlineEnd: '-.5rem',
     marginBlockEnd: '-.5rem',
-    '& > [role="group"]': {
-      flex: '1 0 auto',
-      marginInlineEnd: '.5rem',
-      marginBlockEnd: '.5rem',
+  },
+  flexItemSizeFactor1: {
+    flex: '1 0 auto',
+    marginInlineEnd: '.5rem',
+    marginBlockEnd: '.5rem',
+  },
+  flexItemSizeFactor2: {
+    flex: '2 0 auto',
+    marginInlineEnd: '.5rem',
+    marginBlockEnd: '.5rem',
+  },
+  gridItemSizeFactor1: {},
+  gridItemSizeFactor2: {
+    '@media screen and (min-width: 600px)': {
+      gridColumnEnd: 'span 2',
     },
   },
 })
@@ -50,15 +77,32 @@ const useLayoutStyles = makeStyles({
 export const LayoutItem = (o: LayoutItemEntity) =>
   renderIfCard(o) || renderIfEscape(o) || invalidLayoutItem(o)
 
-export const Layout = ({ layout: { variant, items } }: LayoutProps) => {
+export const Layout = ({
+  layout: { variant, items, itemOptions },
+}: LayoutProps) => {
   const styles = useLayoutStyles()
+
+  const sequenceItemProps = items.map((_, i) => ({
+    contextualClassName:
+      styles[
+        `${variant}ItemSizeFactor${
+          get(itemOptions, [i, 'inlineSizeFactor'], 1) as '1' | '2'
+        }`
+      ],
+  }))
+
   return (
     <section className={cx(styles.root, styles[variant])}>
       {
         <>
-          {Sequence<LayoutItemEntity>(items, LayoutItem, {
-            contextualVariant: 'layout',
-          })}
+          {Sequence<LayoutItemEntity>(
+            items,
+            LayoutItem,
+            {
+              contextualVariant: 'layout',
+            },
+            sequenceItemProps
+          )}
         </>
       }
     </section>

--- a/src/blocks/Layout/Layout.tsx
+++ b/src/blocks/Layout/Layout.tsx
@@ -4,21 +4,13 @@ import { makeStyles, mergeClasses as cx } from '@fluentui/react-components'
 
 import { propsElementUnion, Sequence } from '../../lib'
 
+import { LayoutItemPropsOrElement, renderIfLayoutItem } from './LayoutItem'
+
+import { layoutProps, LayoutProps } from './layout-properties'
 import {
-  LayoutItemPropsOrElement,
-  layoutItemPropsOrElement,
-  renderIfLayoutItem,
-} from './LayoutItem'
-
-import { layoutVariant } from './layout-types'
-
-export const layoutProps = z.object({
-  layout: z.object({
-    variant: layoutVariant,
-    items: z.array(layoutItemPropsOrElement),
-  }),
-})
-export type LayoutProps = z.infer<typeof layoutProps>
+  dashboardPropsOrElement,
+  renderIfDashboard,
+} from './exemplars/Dashboard/Dashboard'
 
 const useLayoutStyles = makeStyles({
   root: {
@@ -67,12 +59,24 @@ function isLayoutElement(
   return o?.type === Layout
 }
 
-export const layoutPropsOrElement = propsElementUnion<
+export const layoutPropsOrElementExact = propsElementUnion<
   typeof layoutProps,
   typeof Layout
 >(layoutProps)
+export type LayoutPropsOrElementExact = z.infer<
+  typeof layoutPropsOrElementExact
+>
+
+export function renderIfLayoutExact(o: any) {
+  return isLayoutProps(o) ? <Layout {...o} /> : isLayoutElement(o) ? o : null
+}
+
+export const layoutPropsOrElement = z.union([
+  layoutPropsOrElementExact,
+  dashboardPropsOrElement,
+])
 export type LayoutPropsOrElement = z.infer<typeof layoutPropsOrElement>
 
 export function renderIfLayout(o: any) {
-  return isLayoutProps(o) ? <Layout {...o} /> : isLayoutElement(o) ? o : null
+  return renderIfLayoutExact(o) || renderIfDashboard(o)
 }

--- a/src/blocks/Layout/LayoutItem.tsx
+++ b/src/blocks/Layout/LayoutItem.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../lib'
 
 import { cardPropsOrElement, renderIfCard } from '../Card/Card'
-import { layoutVariant } from './layout-types'
+import { layoutVariant } from './layout-properties'
 
 export const layoutItemEntity = z.union([cardPropsOrElement, escapeElement])
 export type LayoutItemEntity = z.infer<typeof layoutItemEntity>

--- a/src/blocks/Layout/LayoutItem.tsx
+++ b/src/blocks/Layout/LayoutItem.tsx
@@ -1,0 +1,101 @@
+import { z } from 'zod'
+import { cardPropsOrElement, renderIfCard } from '../Card/Card'
+import {
+  escapeElement,
+  invalidLayoutItem,
+  invalidLayoutItemSelf,
+  propsElementUnion,
+  renderIfEscape,
+} from '../../lib'
+import { makeStyles } from '@fluentui/react-components'
+import { layoutVariant } from './layout-types'
+import { cloneElement, ReactElement } from 'react'
+
+export const layoutItemEntity = z.union([cardPropsOrElement, escapeElement])
+export type LayoutItemEntity = z.infer<typeof layoutItemEntity>
+
+export const layoutItemProps = z
+  .object({
+    item: layoutItemEntity,
+    inlineSizeFactor: z.number().int().gte(1).lte(2).default(1).optional(),
+  })
+  .merge(
+    z
+      .object({
+        contextualVariant: layoutVariant.default('grid'),
+      })
+      .partial()
+  )
+export type LayoutItemProps = z.infer<typeof layoutItemProps>
+
+const useLayoutItemStyles = makeStyles({
+  flexInlineSizeFactor1: {
+    flex: '1 0 auto',
+    marginInlineEnd: '.5rem',
+    marginBlockEnd: '.5rem',
+  },
+  flexInlineSizeFactor2: {
+    flex: '2 0 auto',
+    marginInlineEnd: '.5rem',
+    marginBlockEnd: '.5rem',
+  },
+  gridInlineSizeFactor1: {},
+  gridInlineSizeFactor2: {
+    '@media screen and (min-width: 600px)': {
+      gridColumnEnd: 'span 2',
+    },
+  },
+})
+
+export const LayoutItem = ({
+  item,
+  contextualVariant = 'grid',
+  inlineSizeFactor,
+}: LayoutItemProps) => {
+  const styles = useLayoutItemStyles()
+
+  const contentElement =
+    renderIfCard(item) || renderIfEscape(item) || invalidLayoutItem(item)
+
+  return (
+    contentElement && (
+      <div
+        className={
+          styles[
+            `${contextualVariant}InlineSizeFactor${
+              (inlineSizeFactor || 1).toString() as '1' | '2'
+            }`
+          ]
+        }
+      >
+        {cloneElement(contentElement, { contextualVariant: 'layout' })}
+      </div>
+    )
+  )
+}
+
+function isLayoutItemProps(o: any): o is LayoutItemProps {
+  return 'item' in o
+}
+
+function isLayoutItemElement(
+  o: any
+): o is ReactElement<LayoutItemProps, typeof LayoutItem> {
+  return o?.type === LayoutItem
+}
+
+export const layoutItemPropsOrElement = propsElementUnion<
+  typeof layoutItemProps,
+  typeof LayoutItem
+>(layoutItemProps)
+export type LayoutItemPropsOrElement = z.infer<typeof layoutItemPropsOrElement>
+
+export function renderIfLayoutItem(o: any) {
+  return isLayoutItemProps(o) ? (
+    <LayoutItem {...o} />
+  ) : isLayoutItemElement(o) ? (
+    o
+  ) : (
+    invalidLayoutItemSelf(o)
+  )
+}

--- a/src/blocks/Layout/LayoutItem.tsx
+++ b/src/blocks/Layout/LayoutItem.tsx
@@ -1,5 +1,7 @@
 import { z } from 'zod'
-import { cardPropsOrElement, renderIfCard } from '../Card/Card'
+import { cloneElement, ReactElement } from 'react'
+import { makeStyles, mergeClasses as cx } from '@fluentui/react-components'
+
 import {
   escapeElement,
   invalidLayoutItem,
@@ -7,9 +9,9 @@ import {
   propsElementUnion,
   renderIfEscape,
 } from '../../lib'
-import { makeStyles } from '@fluentui/react-components'
+
+import { cardPropsOrElement, renderIfCard } from '../Card/Card'
 import { layoutVariant } from './layout-types'
-import { cloneElement, ReactElement } from 'react'
 
 export const layoutItemEntity = z.union([cardPropsOrElement, escapeElement])
 export type LayoutItemEntity = z.infer<typeof layoutItemEntity>
@@ -17,7 +19,14 @@ export type LayoutItemEntity = z.infer<typeof layoutItemEntity>
 export const layoutItemProps = z
   .object({
     item: layoutItemEntity,
-    inlineSizeFactor: z.number().int().gte(1).lte(2).default(1).optional(),
+    inlineSizeFactor: z
+      .union([z.literal(1), z.literal(2)])
+      .default(1)
+      .optional(),
+    blockSizeFactor: z
+      .union([z.literal(1), z.literal(2)])
+      .default(1)
+      .optional(),
   })
   .merge(
     z
@@ -39,18 +48,25 @@ const useLayoutItemStyles = makeStyles({
     marginInlineEnd: '.5rem',
     marginBlockEnd: '.5rem',
   },
+  flexBlockSizeFactor1: {},
+  flexBlockSizeFactor2: {},
   gridInlineSizeFactor1: {},
   gridInlineSizeFactor2: {
     '@media screen and (min-width: 600px)': {
       gridColumnEnd: 'span 2',
     },
   },
+  gridBlockSizeFactor1: {},
+  gridBlockSizeFactor2: {
+    gridRowEnd: 'span 2',
+  },
 })
 
 export const LayoutItem = ({
   item,
   contextualVariant = 'grid',
-  inlineSizeFactor,
+  inlineSizeFactor = 1,
+  blockSizeFactor = 1,
 }: LayoutItemProps) => {
   const styles = useLayoutItemStyles()
 
@@ -60,13 +76,18 @@ export const LayoutItem = ({
   return (
     contentElement && (
       <div
-        className={
+        className={cx(
           styles[
             `${contextualVariant}InlineSizeFactor${
-              (inlineSizeFactor || 1).toString() as '1' | '2'
+              inlineSizeFactor.toString() as '1' | '2'
+            }`
+          ],
+          styles[
+            `${contextualVariant}BlockSizeFactor${
+              blockSizeFactor.toString() as '1' | '2'
             }`
           ]
-        }
+        )}
       >
         {cloneElement(contentElement, { contextualVariant: 'layout' })}
       </div>

--- a/src/blocks/Layout/StorybookLayout.tsx
+++ b/src/blocks/Layout/StorybookLayout.tsx
@@ -1,4 +1,4 @@
-import { LayoutProps } from './Layout'
+import { LayoutProps } from './layout-properties'
 import { FluentPatternsProvider, ThemeName } from '../../lib'
 import { Main } from '../../surfaces'
 import { InlineSequenceOrString } from '../../inlines'
@@ -6,10 +6,10 @@ import { InlineSequenceOrString } from '../../inlines'
 export const Layout = ({
   theme,
   ...props
-}: LayoutProps['layout'] & { theme: ThemeName }) => (
+}: LayoutProps & { theme: ThemeName }) => (
   <FluentPatternsProvider themeName={theme}>
     <Main
-      blocks={[{ layout: props }]}
+      blocks={[{ ...props }]}
       title={null as unknown as InlineSequenceOrString}
     />
   </FluentPatternsProvider>

--- a/src/blocks/Layout/exemplars/Dashboard/Dashboard.tsx
+++ b/src/blocks/Layout/exemplars/Dashboard/Dashboard.tsx
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+import { ReactElement } from 'react'
+
+import { propsElementUnion } from '../../../../lib'
+
+import { Layout } from '../../Layout'
+import { LayoutProps } from '../../layout-properties'
+import { widgetPropsOrElement } from '../../../Card/exemplars/Widget'
+import { layoutItemProps } from '../../LayoutItem'
+
+export const dashboardProps = z.object({
+  dashboard: z.object({
+    items: z.array(
+      layoutItemProps
+        .pick({ inlineSizeFactor: true, blockSizeFactor: true })
+        .merge(
+          z.object({
+            item: widgetPropsOrElement,
+          })
+        )
+    ),
+  }),
+})
+export type DashboardProps = z.infer<typeof dashboardProps>
+
+export const dashboardLayout = ({
+  dashboard: { items },
+}: DashboardProps): LayoutProps => ({
+  layout: { variant: 'grid', items },
+})
+
+export const Dashboard = (props: DashboardProps) => (
+  <Layout {...dashboardLayout(props)} />
+)
+
+function isDashboardProps(o: any): o is DashboardProps {
+  return 'dashboard' in o
+}
+
+function isDashboardElement(
+  o: any
+): o is ReactElement<DashboardProps, typeof Dashboard> {
+  return o?.type === Dashboard
+}
+
+export const dashboardPropsOrElement = propsElementUnion<
+  typeof dashboardProps,
+  typeof Dashboard
+>(dashboardProps)
+export type DashboardPropsOrElement = z.infer<typeof dashboardPropsOrElement>
+
+export function renderIfDashboard(o: any) {
+  return isDashboardProps(o) ? (
+    <Dashboard {...o} />
+  ) : isDashboardElement(o) ? (
+    o
+  ) : null
+}

--- a/src/blocks/Layout/layout-properties.ts
+++ b/src/blocks/Layout/layout-properties.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+import { layoutItemPropsOrElement } from './LayoutItem'
+
+export const layoutVariant = z.union([z.literal('grid'), z.literal('flex')])
+export type LayoutVariant = z.infer<typeof layoutVariant>
+
+export const layoutProps = z.object({
+  layout: z.object({
+    variant: layoutVariant,
+    items: z.array(layoutItemPropsOrElement),
+  }),
+})
+export type LayoutProps = z.infer<typeof layoutProps>

--- a/src/blocks/Layout/layout-types.ts
+++ b/src/blocks/Layout/layout-types.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod'
+
+export const layoutVariant = z.union([z.literal('grid'), z.literal('flex')])
+export type LayoutVariant = z.infer<typeof layoutVariant>

--- a/src/blocks/Layout/layout-types.ts
+++ b/src/blocks/Layout/layout-types.ts
@@ -1,4 +1,0 @@
-import { z } from 'zod'
-
-export const layoutVariant = z.union([z.literal('grid'), z.literal('flex')])
-export type LayoutVariant = z.infer<typeof layoutVariant>

--- a/src/blocks/ShortInputs/ShortInputs.test-stories.tsx
+++ b/src/blocks/ShortInputs/ShortInputs.test-stories.tsx
@@ -1,0 +1,28 @@
+import { ShortInputs, ShortInputsProps } from './ShortInputs'
+import { Parameters } from '@storybook/addons'
+import { Escape } from '../../lib'
+
+export default {
+  title: 'Tests/Sis',
+  component: ShortInputs,
+}
+
+const ShortInputsTemplate = (props: ShortInputsProps) => (
+  <ShortInputs {...props} />
+)
+
+export const ShortInputsJsonTest: typeof ShortInputsTemplate & {
+  args?: ShortInputsProps
+  parameters?: Parameters
+} = ShortInputsTemplate.bind({})
+
+ShortInputsJsonTest.args = {
+  inputs: [
+    {
+      type: 'button',
+      label: '37db439e-ea0f-44b6-8fbe-61138ad48601',
+      actionId: '034919a8-d48e-4707-82c2-26b02c4348ba',
+    },
+  ],
+}
+ShortInputsJsonTest.parameters = { chromatic: { disableSnapshot: true } }

--- a/src/blocks/ShortInputs/ShortInputs.test.tsx
+++ b/src/blocks/ShortInputs/ShortInputs.test.tsx
@@ -3,5 +3,5 @@
 import expect from 'expect'
 
 describe('Short inputs', function () {
-  it('is still in placeholder stage')
+  it('iS READY FOR TESTS')
 })

--- a/src/blocks/ShortInputs/ShortInputs.test.tsx
+++ b/src/blocks/ShortInputs/ShortInputs.test.tsx
@@ -3,5 +3,21 @@
 import expect from 'expect'
 
 describe('Short inputs', function () {
-  it('iS READY FOR TESTS')
+  describe('interactions', function () {
+    this.timeout(5e3)
+    describe('using serializeable props', function () {
+      before(async function () {
+        await this.goto(this.storybookUrl('tests-sis--short-inputs-json-test'))
+      })
+      it('renders to the page', async function () {
+        expect(
+          await this.page
+            .locator(
+              '#root button >> text=37db439e-ea0f-44b6-8fbe-61138ad48601'
+            )
+            .count()
+        ).toEqual(1)
+      })
+    })
+  })
 })

--- a/src/blocks/ShortInputs/ShortInputs.tsx
+++ b/src/blocks/ShortInputs/ShortInputs.tsx
@@ -57,8 +57,6 @@ const useShortInputsStyles = makeStyles({
   'shortInputSequence--flex': {
     display: 'flex',
     flexFlow: 'row wrap',
-    marginInlineEnd: '-.5rem',
-    marginBlockEnd: '-.5rem',
     gap: '.5rem',
   },
   'shortInputSequence--narrow-block': {

--- a/src/blocks/ShortInputs/ShortInputs.tsx
+++ b/src/blocks/ShortInputs/ShortInputs.tsx
@@ -6,6 +6,7 @@ import {
   escapeElement,
   invalidShortInput,
   propsElementUnion,
+  rem,
   renderIfEscape,
   Sequence,
   useCommonStyles,
@@ -61,10 +62,10 @@ const useShortInputsStyles = makeStyles({
     gap: '.5rem',
   },
   'shortInputSequence--narrow-block': {
-    marginBlockStart: '.5rem',
-    '& > *': {
-      marginBlockEnd: '.5rem',
-    },
+    marginBlockStart: rem(20),
+    display: 'flex',
+    flexFlow: 'column nowrap',
+    gap: '.5rem',
   },
 })
 

--- a/src/blocks/ShortInputs/ShortInputs.tsx
+++ b/src/blocks/ShortInputs/ShortInputs.tsx
@@ -59,10 +59,7 @@ const useShortInputsStyles = makeStyles({
     flexFlow: 'row wrap',
     marginInlineEnd: '-.5rem',
     marginBlockEnd: '-.5rem',
-    '& > *': {
-      marginInlineEnd: '.5rem',
-      marginBlockEnd: '.5rem',
-    },
+    gap: '.5rem',
   },
   'shortInputSequence--narrow-block': {
     marginBlockStart: '.5rem',

--- a/src/blocks/ShortInputs/ShortInputs.tsx
+++ b/src/blocks/ShortInputs/ShortInputs.tsx
@@ -95,7 +95,10 @@ export const ShortInputs = (props: ShortInputsProps) => {
         ])}
       >
         {Sequence<ShortInputEntity>(inputs, ShortInput, {
-          contextualVariant: `${contextualVariant}-inputs`,
+          contextualVariant:
+            variant === 'narrow-block'
+              ? 'narrow-inputs'
+              : `${contextualVariant}-inputs`,
         })}
       </div>
     </div>

--- a/src/blocks/ShortInputs/ShortInputs.tsx
+++ b/src/blocks/ShortInputs/ShortInputs.tsx
@@ -27,18 +27,32 @@ export type ShortInputEntity = z.infer<typeof shortInputEntity>
 export const shortInputSequence = z.array(shortInputEntity)
 export type ShortInputSequence = z.infer<typeof shortInputSequence>
 
-const shortInputsProps = z.object({
-  inputs: shortInputSequence,
-  variant: z
-    .union([z.literal('flex'), z.literal('narrow-block')])
-    .default('flex')
-    .optional(),
-})
+const shortInputsProps = z
+  .object({
+    inputs: shortInputSequence,
+    variant: z
+      .union([z.literal('flex'), z.literal('narrow-block')])
+      .default('flex')
+      .optional(),
+  })
+  .merge(
+    z
+      .object({
+        contextualVariant: z
+          .union([z.literal('card'), z.literal('block')])
+          .default('block'),
+      })
+      .partial()
+  )
 export type ShortInputsProps = z.infer<typeof shortInputsProps>
 
 const useShortInputsStyles = makeStyles({
   root: {
     marginBlockEnd: '.5rem',
+  },
+  cardContext: {
+    marginInlineStart: '-.5rem',
+    marginInlineEnd: '-.5rem',
   },
   'shortInputSequence--flex': {
     display: 'flex',
@@ -65,26 +79,29 @@ const ShortInput = (o: ShortInputEntity) =>
   invalidShortInput(o)
 
 export const ShortInputs = (props: ShortInputsProps) => {
-  const { inputs, variant = 'flex' } = props
-  const styles = useShortInputsStyles()
+  const { inputs, variant = 'flex', contextualVariant = 'block' } = props
+  const shortInputsStyles = useShortInputsStyles()
   const commonStyles = useCommonStyles()
   return (
     <div
       className={cx(
         commonStyles.centerBlock,
         commonStyles.mainContentWidth,
-        styles.root
+        shortInputsStyles.root,
+        contextualVariant === 'card' && shortInputsStyles.cardContext
       )}
     >
       <div
         className={cx.apply(this, [
-          styles[`shortInputSequence--${variant}`],
+          shortInputsStyles[`shortInputSequence--${variant}`],
           ...(variant === 'narrow-block'
             ? [commonStyles.narrowWidth, commonStyles.centerBlock]
             : []),
         ])}
       >
-        {Sequence<ShortInputEntity>(inputs, ShortInput)}
+        {Sequence<ShortInputEntity>(inputs, ShortInput, {
+          contextualVariant: `${contextualVariant}-inputs`,
+        })}
       </div>
     </div>
   )

--- a/src/blocks/ShortInputs/ShortInputs.tsx
+++ b/src/blocks/ShortInputs/ShortInputs.tsx
@@ -53,6 +53,7 @@ const useShortInputsStyles = makeStyles({
   cardContext: {
     marginInlineStart: '-.5rem',
     marginInlineEnd: '-.5rem',
+    marginBlockEnd: 0,
   },
   'shortInputSequence--flex': {
     display: 'flex',

--- a/src/blocks/Tabs/Tabs.stories.mdx
+++ b/src/blocks/Tabs/Tabs.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs'
 import { fake, seed } from 'faker/locale/en_US'
+import fakeTitle from '../../lib/fakeTitle'
 import range from 'lodash/range'
 
 import { Tabs } from './StorybookTabs'
@@ -23,10 +24,10 @@ export const TabsTemplate = (props) => <Tabs {...props} />
     args={{
       theme: 'light',
       tabs: range(4).map(() => ({
-        tab: { label: fake('{{lorem.words}}') },
+        tab: { label: fakeTitle() },
         panel: [{ paragraph: [{ text: fake('{{lorem.paragraph}}') }] }],
       })),
-      label: fake('{{lorem.words}}'),
+      label: fakeTitle(),
     }}
   >
     {seed(1234) || TabsTemplate.bind({})}

--- a/src/blocks/Tabs/Tabs.stories.mdx
+++ b/src/blocks/Tabs/Tabs.stories.mdx
@@ -24,10 +24,10 @@ export const TabsTemplate = (props) => <Tabs {...props} />
     args={{
       theme: 'light',
       tabs: range(4).map(() => ({
-        tab: { label: fakeTitle() },
+        tab: { label: fakeTitle(fake) },
         panel: [{ paragraph: [{ text: fake('{{lorem.paragraph}}') }] }],
       })),
-      label: fakeTitle(),
+      label: fakeTitle(fake),
     }}
   >
     {seed(1234) || TabsTemplate.bind({})}

--- a/src/blocks/Tabs/Tabs.test.tsx
+++ b/src/blocks/Tabs/Tabs.test.tsx
@@ -26,6 +26,8 @@ describe('Tabs', function () {
             .count()
         ).toEqual(1)
       })
+
+      it('moves focus and switches tabs correctly for keyboard users')
     })
 
     describe('using JSX', function () {

--- a/src/blocks/Tabs/Tabs.tsx
+++ b/src/blocks/Tabs/Tabs.tsx
@@ -44,6 +44,7 @@ export const tabPanelItemEntity = z.union([
 export type TabPanelItemEntity = z.infer<typeof tabPanelItemEntity>
 
 export const tabPanelItemSequence = z.array(tabPanelItemEntity)
+export type TabPanelItemSequence = z.infer<typeof tabPanelItemSequence>
 
 const TabPanelItem = (o: TabPanelItemEntity) =>
   renderIfHeading(o) ||

--- a/src/blocks/Tabs/Tabs.tsx
+++ b/src/blocks/Tabs/Tabs.tsx
@@ -24,6 +24,10 @@ import {
   renderIfShortInputs,
   shortInputsPropsOrElement,
 } from '../ShortInputs/ShortInputs'
+import {
+  descriptionListPropsOrElement,
+  renderIfDescriptionList,
+} from '../DescriptionList/DescriptionList'
 
 export const tabProps = buttonProps.omit({
   type: true,
@@ -39,6 +43,7 @@ export const tabPanelItemEntity = z.union([
   paragraphPropsOrElement,
   figurePropsOrElement,
   shortInputsPropsOrElement,
+  descriptionListPropsOrElement,
   escapeElement,
 ])
 export type TabPanelItemEntity = z.infer<typeof tabPanelItemEntity>
@@ -51,6 +56,7 @@ const TabPanelItem = (o: TabPanelItemEntity) =>
   renderIfParagraph(o) ||
   renderIfFigure(o) ||
   renderIfShortInputs(o) ||
+  renderIfDescriptionList(o) ||
   renderIfEscape(o) ||
   invalidTabPanelItem(o)
 

--- a/src/blocks/Tabs/Tabs.tsx
+++ b/src/blocks/Tabs/Tabs.tsx
@@ -60,18 +60,28 @@ export const tabsItemProps = z.object({
 })
 export type TabsItemProps = z.infer<typeof tabsItemProps>
 
-export const tabsProps = z.object({
-  label: z.string(),
-  tabs: z.array(tabsItemProps),
-  tabVariant: z
-    .union([z.literal('subtle'), z.literal('transparent')])
-    .default('transparent')
-    .optional(),
-  tabListVariant: z
-    .union([z.literal('start'), z.literal('center')])
-    .default('start')
-    .optional(),
-})
+export const tabsProps = z
+  .object({
+    label: z.string(),
+    tabs: z.array(tabsItemProps),
+    tabVariant: z
+      .union([z.literal('subtle'), z.literal('transparent')])
+      .default('transparent')
+      .optional(),
+    tabListVariant: z
+      .union([z.literal('start'), z.literal('center')])
+      .default('start')
+      .optional(),
+  })
+  .merge(
+    z
+      .object({
+        contextualVariant: z
+          .union([z.literal('card'), z.literal('block')])
+          .default('block'),
+      })
+      .partial()
+  )
 export type TabsProps = z.infer<typeof tabsProps>
 
 const useTabsStyles = makeStyles({
@@ -85,8 +95,15 @@ const useTabsStyles = makeStyles({
     paddingBlockStart: rem(2),
     paddingBlockEnd: rem(2),
   },
+  tabListCardContext: {
+    marginInlineStart: '-.5rem',
+    marginInlineEnd: '-.5rem',
+  },
   tabListCenter: {
     justifyContent: 'center',
+  },
+  tabs: {
+    flexGrow: 1,
   },
 })
 
@@ -102,19 +119,21 @@ export const Tabs = ({
   label,
   tabVariant = 'transparent',
   tabListVariant = 'start',
+  contextualVariant = 'block',
 }: TabsProps) => {
   const [activeTab, setActiveTab] = useState(0)
   const itemIds = tabs.map(() => uniqueId('tabItem'))
   const tabsStyles = useTabsStyles()
   const commonStyles = useCommonStyles()
   return (
-    <div aria-label={label}>
+    <div aria-label={label} className={tabsStyles.tabs}>
       <div className={cx(commonStyles.centerBlock, tabsStyles.tabScrollCtx)}>
         <div
           role="tablist"
           className={cx(
             tabsStyles.tabList,
-            tabListVariant === 'center' && tabsStyles.tabListCenter
+            tabListVariant === 'center' && tabsStyles.tabListCenter,
+            contextualVariant === 'card' && tabsStyles.tabListCardContext
           )}
         >
           {tabs.map((tabItem, t) => (
@@ -128,6 +147,7 @@ export const Tabs = ({
                 contextualVariant: 'tabs',
                 selected: activeTab === t,
                 controls: panelId(itemIds[t]),
+                size: contextualVariant === 'block' ? 'medium' : 'small',
                 onAction: () => {
                   setActiveTab(t)
                 },
@@ -140,7 +160,7 @@ export const Tabs = ({
         <div
           key={itemIds[t]}
           id={panelId(itemIds[t])}
-          tabIndex={0}
+          tabIndex={activeTab !== t ? -1 : 0}
           role="tabpanel"
           aria-labelledby={tabId(itemIds[t])}
           {...(activeTab !== t && { hidden: true })}

--- a/src/inputs/Button/Button.tsx
+++ b/src/inputs/Button/Button.tsx
@@ -52,7 +52,7 @@ export type ButtonProps = z.infer<typeof buttonProps>
 
 const useButtonStyles = makeStyles({
   root: {
-    margin: 'inherit',
+    margin: 0,
     flexShrink: 0,
   },
   tab: (theme) => ({

--- a/src/inputs/Button/Button.tsx
+++ b/src/inputs/Button/Button.tsx
@@ -14,6 +14,7 @@ import {
   rem,
 } from '../../lib'
 import { Icon, iconSize, iconVariant } from '../../inlines'
+import { shortInputContextualVariants } from '../input-properties'
 
 export const buttonActivateAction = actionPayload.merge(
   z.object({
@@ -36,6 +37,9 @@ export const buttonProps = z
         z.literal('transparent'),
       ])
       .optional(),
+    size: z
+      .union([z.literal('small'), z.literal('medium'), z.literal('large')])
+      .optional(),
     iconOnly: z.boolean().optional(),
     icon: z.string().optional(),
     iconPosition: z.union([z.literal('before'), z.literal('after')]).optional(),
@@ -43,17 +47,7 @@ export const buttonProps = z
     iconVariant: iconVariant.optional(),
     ...withActionHandler(buttonActivateAction),
   })
-  .merge(
-    z
-      .object({
-        contextualVariant: z
-          .union([z.literal('inputs'), z.literal('tabs')])
-          .default('inputs'),
-        selected: z.boolean().default(false),
-        controls: z.string(),
-      })
-      .partial()
-  )
+  .merge(shortInputContextualVariants)
 export type ButtonProps = z.infer<typeof buttonProps>
 
 const useButtonStyles = makeStyles({
@@ -120,13 +114,14 @@ export const Button = ({
   icon,
   iconPosition,
   variant,
+  size,
   iconSize,
   iconVariant,
   actionId,
   onAction,
-  contextualVariant,
   selected,
   controls,
+  contextualVariant = 'block-inputs',
 }: ButtonProps) => {
   const context = useFluentPatternsContext()
 
@@ -138,11 +133,16 @@ export const Button = ({
 
   const buttonStyles = useButtonStyles()
 
+  const derivedSize =
+    contextualVariant === 'card-inputs' ? 'small' : size || 'medium'
+  const derivedIconSize =
+    iconSize || derivedSize === 'small' ? 16 : derivedSize === 'large' ? 32 : 24
+
   return (
     <FluentButton
-      {...(contextualVariant !== 'tabs' && { block: true })}
       aria-label={label}
       appearance={variant}
+      size={derivedSize}
       className={cx(
         buttonStyles.root,
         contextualVariant === 'tabs' && buttonStyles.tab,
@@ -153,7 +153,7 @@ export const Button = ({
         icon: (
           <Icon
             icon={icon}
-            size={iconSize || 24}
+            size={derivedIconSize}
             variant={
               contextualVariant === 'tabs'
                 ? selected

--- a/src/inputs/Button/Button.tsx
+++ b/src/inputs/Button/Button.tsx
@@ -55,6 +55,9 @@ const useButtonStyles = makeStyles({
     margin: 0,
     flexShrink: 0,
   },
+  fill: {
+    width: '100%',
+  },
   tab: (theme) => ({
     position: 'relative',
     fontWeight: theme.fontWeightRegular,
@@ -145,6 +148,7 @@ export const Button = ({
       size={derivedSize}
       className={cx(
         buttonStyles.root,
+        contextualVariant === 'narrow-inputs' && buttonStyles.fill,
         contextualVariant === 'tabs' && buttonStyles.tab,
         contextualVariant === 'tabs' && selected && buttonStyles.tabSelected
       )}

--- a/src/inputs/input-properties.ts
+++ b/src/inputs/input-properties.ts
@@ -26,3 +26,17 @@ export const labeledValueProps = z.object({
   value: z.string().nonempty(),
   label: inlineSequenceOrString,
 })
+
+export const shortInputContextualVariants = z
+  .object({
+    contextualVariant: z
+      .union([
+        z.literal('block-inputs'),
+        z.literal('card-inputs'),
+        z.literal('tabs'),
+      ])
+      .default('block-inputs'),
+    selected: z.boolean().default(false),
+    controls: z.string(),
+  })
+  .partial()

--- a/src/inputs/input-properties.ts
+++ b/src/inputs/input-properties.ts
@@ -33,6 +33,7 @@ export const shortInputContextualVariants = z
       .union([
         z.literal('block-inputs'),
         z.literal('card-inputs'),
+        z.literal('narrow-inputs'),
         z.literal('tabs'),
       ])
       .default('block-inputs'),

--- a/src/lib/Sequence.tsx
+++ b/src/lib/Sequence.tsx
@@ -7,16 +7,20 @@ type FCElementConstructor<P> = (props: P) => ReactElement<P> | null
 export function Sequence<P>(
   entities: P[] | undefined,
   Entity: FCElementConstructor<P>,
-  props?: Record<string, any>
+  sharedProps?: Record<string, any>,
+  uniqueProps?: Record<string, any>[]
 ) {
   return (
     <>
-      {(entities ?? []).map((o: P) => {
+      {(entities ?? []).map((o: P, index) => {
         const contentElement = Entity(o)
         return (
           contentElement &&
-          cloneElement(contentElement, { key: key(o), ...props } as Partial<P> &
-            Attributes)
+          cloneElement(contentElement, {
+            key: key(o),
+            ...sharedProps,
+            ...(uniqueProps && uniqueProps[index]),
+          } as Partial<P> & Attributes)
         )
       })}
     </>

--- a/src/lib/commonStyles.ts
+++ b/src/lib/commonStyles.ts
@@ -5,6 +5,9 @@ export const useCommonStyles = makeStyles({
   mainContentWidth: {
     maxWidth: rem(572),
   },
+  mainContentWidthEncapsulated: {
+    maxWidth: rem(572 + 40),
+  },
   narrowWidth: {
     maxWidth: rem(280),
   },

--- a/src/lib/commonStyles.ts
+++ b/src/lib/commonStyles.ts
@@ -56,11 +56,7 @@ export const useTextBlockStyles = makeStyles({
     lineHeight: 24 / 18,
   }),
   cardSpacing: {
-    marginBlockStart: 0,
-    marginInlineStart: 0,
-    marginInlineEnd: 0,
-    marginBlockEnd: rem(12),
-    '&:last-child': { marginBlockEnd: 0 },
+    margin: 0,
   },
   h1: {
     fontSize: rem(24),

--- a/src/lib/commonStyles.ts
+++ b/src/lib/commonStyles.ts
@@ -56,7 +56,11 @@ export const useTextBlockStyles = makeStyles({
     lineHeight: 24 / 18,
   }),
   cardSpacing: {
-    margin: 0,
+    marginBlockStart: 0,
+    marginInlineStart: 0,
+    marginInlineEnd: 0,
+    marginBlockEnd: rem(12),
+    '&:last-child': { marginBlockEnd: 0 },
   },
   h1: {
     fontSize: rem(24),

--- a/src/lib/fakeTitle.ts
+++ b/src/lib/fakeTitle.ts
@@ -1,6 +1,6 @@
-import { fake } from 'faker'
+import Faker from 'faker'
 
-export default function fakeTitle() {
+export default function fakeTitle(fake: Faker.FakerStatic['fake']) {
   const lowercase = fake('{{lorem.words}}')
   return lowercase.charAt(0).toUpperCase() + lowercase.slice(1)
 }

--- a/src/lib/fakeTitle.ts
+++ b/src/lib/fakeTitle.ts
@@ -1,0 +1,6 @@
+import { fake } from 'faker'
+
+export default function fakeTitle() {
+  const lowercase = fake('{{lorem.words}}')
+  return lowercase.charAt(0).toUpperCase() + lowercase.slice(1)
+}

--- a/src/lib/warnings.ts
+++ b/src/lib/warnings.ts
@@ -3,6 +3,9 @@ import { warn } from './log'
 export const invalidInline = warn('Invalid inline element')
 export const invalidBlock = warn('Invalid block element')
 export const invalidLayoutItem = warn('Invalid layout item element')
+export const invalidLayoutItemSelf = warn(
+  'Layout and LayoutItem are tightly-bound; Layout will only accept LayoutItem props or elements as items.'
+)
 export const invalidCardContentItem = warn('Invalid card content item element')
 export const invalidTabPanelItem = warn('Invalid tab panel item element')
 export const invalidShortInput = warn('Invalid short input element')

--- a/src/media/Chart/variants/BubbleChart.tsx
+++ b/src/media/Chart/variants/BubbleChart.tsx
@@ -18,6 +18,9 @@ import { BubbleChartDatum, ChartData } from '../chart-types'
 import { Legend } from '../Legend'
 import { useChartStyles } from '../chart-styles'
 
+/**
+ * @internal
+ */
 export const BubbleChart = memo(
   // eslint-disable-next-line max-lines-per-function
   ({ label, data }: { label: string; data: ChartData }) => {

--- a/src/media/Chart/variants/HorizontalBarChart.tsx
+++ b/src/media/Chart/variants/HorizontalBarChart.tsx
@@ -19,6 +19,9 @@ import { FluentPatternsContext, useTranslations } from '../../../lib'
 import { Legend } from '../Legend'
 import { useChartStyles } from '../chart-styles'
 
+/**
+ * @internal
+ */
 export const HorizontalBarChart = memo(
   // eslint-disable-next-line max-lines-per-function
   ({

--- a/src/media/Chart/variants/LineChart.tsx
+++ b/src/media/Chart/variants/LineChart.tsx
@@ -15,6 +15,9 @@ import { FluentPatternsContext, useTranslations } from '../../../lib'
 import { Legend } from '../Legend'
 import { useChartStyles } from '../chart-styles'
 
+/**
+ * @internal
+ */
 export const LineChart = memo(
   // eslint-disable-next-line max-lines-per-function
   ({

--- a/src/media/Chart/variants/PieChart.tsx
+++ b/src/media/Chart/variants/PieChart.tsx
@@ -28,6 +28,9 @@ export type PieChartProps = {
   cutoutPercentage?: number
 }
 
+/**
+ * @internal
+ */
 export const PieChart = memo(
   // eslint-disable-next-line max-lines-per-function
   ({ label, data, cutoutPercentage }: PieChartProps) => {

--- a/src/media/Chart/variants/StackedLineChart.tsx
+++ b/src/media/Chart/variants/StackedLineChart.tsx
@@ -20,6 +20,9 @@ import { FluentPatternsContext, useTranslations } from '../../../lib'
 import { Legend } from '../Legend'
 import { useChartStyles } from '../chart-styles'
 
+/**
+ * @internal
+ */
 export const StackedLineChart = memo(
   // eslint-disable-next-line max-lines-per-function
   ({ label, data }: { label: string; data: ChartData }) => {

--- a/src/media/Chart/variants/VerticalBarChart.tsx
+++ b/src/media/Chart/variants/VerticalBarChart.tsx
@@ -19,6 +19,9 @@ import { FluentPatternsContext, useTranslations } from '../../../lib'
 import { Legend } from '../Legend'
 import { useChartStyles } from '../chart-styles'
 
+/**
+ * @internal
+ */
 export const VerticalBarChart = memo(
   // eslint-disable-next-line max-lines-per-function
   ({

--- a/src/media/Illustration/variants/Default.tsx
+++ b/src/media/Illustration/variants/Default.tsx
@@ -267,4 +267,7 @@ const illustration = {
   ),
 }
 
+/**
+ * @internal
+ */
 export default illustration

--- a/src/media/Illustration/variants/Empty.tsx
+++ b/src/media/Illustration/variants/Empty.tsx
@@ -252,4 +252,7 @@ const illustration = {
   ),
 }
 
+/**
+ * @internal
+ */
 export default illustration

--- a/src/media/Illustration/variants/Error.tsx
+++ b/src/media/Illustration/variants/Error.tsx
@@ -91,4 +91,7 @@ const illustration = {
   ),
 }
 
+/**
+ * @internal
+ */
 export default illustration

--- a/src/media/Illustration/variants/Hello.tsx
+++ b/src/media/Illustration/variants/Hello.tsx
@@ -265,4 +265,7 @@ const illustration = {
     </svg>
   ),
 }
+/**
+ * @internal
+ */
 export default illustration

--- a/src/media/Illustration/variants/Thanks.tsx
+++ b/src/media/Illustration/variants/Thanks.tsx
@@ -537,4 +537,8 @@ const illustration = {
     </svg>
   ),
 }
+
+/**
+ * @internal
+ */
 export default illustration

--- a/src/views/View/View.stories.mdx
+++ b/src/views/View/View.stories.mdx
@@ -105,11 +105,22 @@ that time `View` will call its interaction callback with the update.
             ],
             sections: range(2).map(() => ({
               title: [{ text: fakeTitle(fake) }],
-              blocks: range(3).map(() => ({
-                paragraph: range(3).map(() => ({
-                  text: fake('{{lorem.sentence}} '),
+              blocks: [
+                ...range(3).map(() => ({
+                  paragraph: range(3).map(() => ({
+                    text: fake('{{lorem.sentence}} '),
+                  })),
                 })),
-              })),
+                {
+                  card: [
+                    {
+                      paragraph: fakeTitle(fake),
+                      level: 3,
+                    },
+                    { paragraph: fake('{{lorem.paragraph}}') },
+                  ],
+                },
+              ],
             })),
           }),
         })),

--- a/src/views/View/View.stories.mdx
+++ b/src/views/View/View.stories.mdx
@@ -1,5 +1,6 @@
 import range from 'lodash/range'
 import { fake, seed } from 'faker/locale/en_US'
+import fakeTitle from '../../lib/fakeTitle'
 import { View } from './View'
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
 
@@ -27,11 +28,6 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
     viewMode: 'docs',
   }}
 />
-
-export const fakeTitle = () => {
-  const lowercase = fake('{{lorem.words}}')
-  return lowercase.charAt(0).toUpperCase() + lowercase.slice(1)
-}
 
 export const ViewTemplate = (props) => <View {...props} />
 

--- a/src/views/View/View.stories.mdx
+++ b/src/views/View/View.stories.mdx
@@ -11,10 +11,6 @@ import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
       name: 'Main',
       control: { type: 'object' },
     },
-    dir: {
-      name: 'Text direction',
-      control: { type: 'inline-radio', labels: { ltr: '→', rtl: '←' } },
-    },
     theme: {
       name: 'Theme variant',
       control: {
@@ -122,7 +118,6 @@ that time `View` will call its interaction callback with the update.
           }),
         })),
       },
-      dir: 'ltr',
       theme: 'light',
     }}
   >

--- a/src/views/View/View.tsx
+++ b/src/views/View/View.tsx
@@ -3,10 +3,11 @@ import { z } from 'zod'
 import {
   FluentPatternsProvider,
   themeName,
-  dir,
   ParseBoundary,
   withActionHandler,
   anyActionPayload,
+  translations,
+  defaultTranslations,
 } from '../../lib'
 
 import { Main } from '../../surfaces'
@@ -18,7 +19,7 @@ export const viewProps = z.object({
   modal: z.object({}).optional(),
   main: sectionContentProps,
   theme: themeName.optional(),
-  dir: dir.optional(),
+  translations: translations.optional(),
   ...withActionHandler(anyActionPayload),
 })
 
@@ -29,8 +30,13 @@ export const View = (data: ViewProps) => (
   <ParseBoundary<ViewProps>
     schema={viewProps}
     data={data}
-    children={({ main, theme = 'light', dir = 'ltr', onAction }) => (
-      <FluentPatternsProvider {...{ theme, dir, onAction }}>
+    children={({
+      main,
+      theme = 'light',
+      translations = defaultTranslations,
+      onAction,
+    }) => (
+      <FluentPatternsProvider {...{ theme, translations, onAction }}>
         <Main {...main} />
       </FluentPatternsProvider>
     )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1764,17 +1764,17 @@
   resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
-"@storybook/addon-actions@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.4.13.tgz#3c33cbffb8857f27f528d0e35ae9ba806d95ee0b"
-  integrity sha512-Bf/M3Kdq60xj48oXnRCm7+qstWL9wT8rjFPFm7+A0NSfVSlox6pFU5SfPuOI4Za/6Ll2XDaYwsaF3QYHX0jQAA==
+"@storybook/addon-actions@6.4.14", "@storybook/addon-actions@latest":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-6.4.14.tgz#be5590438943487b4243b2fe16619557cb9ca0ce"
+  integrity sha512-EBraATDCKCbb1IpT+bTIV+noFIoK5ykXj8Nt0qmQGD2OC1cZovIyH3DigyD0/3D55znGzxqRruTK8lm0nc1jbg==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/api" "6.4.13"
-    "@storybook/components" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/api" "6.4.14"
+    "@storybook/components" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/theming" "6.4.13"
+    "@storybook/theming" "6.4.14"
     core-js "^3.8.2"
     fast-deep-equal "^3.1.3"
     global "^4.4.0"
@@ -1788,18 +1788,18 @@
     util-deprecate "^1.0.2"
     uuid-browser "^3.1.0"
 
-"@storybook/addon-backgrounds@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-6.4.13.tgz#e233daa7e5bcf417bfd885e1ad7e2d8d7873e9ad"
-  integrity sha512-U+TowEgEHCWifdnaJE5P7kgRHjYrztwpjp/8tX4iXHlCVFBFid+v4EKqXQGbvTzX66g2Yfv/h68NGEpcFW/svQ==
+"@storybook/addon-backgrounds@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-6.4.14.tgz#6e55963857993f6a55a01dc8df99c60224bb86af"
+  integrity sha512-/lWCmg32cM3jdoiaYXgN2Itde49DXsjPKuttSvb8DS7aFQEV7jNnpta4vN5OtoBtAY6tgDn3V0Cft9D7xWqzBA==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/api" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/components" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/api" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/components" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/theming" "6.4.13"
+    "@storybook/theming" "6.4.14"
     core-js "^3.8.2"
     global "^4.4.0"
     memoizerific "^1.11.3"
@@ -1807,28 +1807,28 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/addon-controls@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-6.4.13.tgz#7875abb01ddcf893dd915bf2f965f97b53cfae84"
-  integrity sha512-XDaeYcwCi4qQ8hGXn4Mbdb6CQGGfZoBm5UjUaWBjDJdo54AyZv3VYdNgWFdiitqk5LRyh2omHD54EditM774NQ==
+"@storybook/addon-controls@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-6.4.14.tgz#05a2d58175bf5af00d408386f18bcb2f62da431b"
+  integrity sha512-12d0Bw0TsueyaQOKMzWTm+G4d78yKXRdX7NP6q6h0HWdqGFdcsuZ60QcQh+GExR9z/M2laDSIijTBZtEJggWGQ==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/api" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/components" "6.4.13"
-    "@storybook/core-common" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/api" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/components" "6.4.14"
+    "@storybook/core-common" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/node-logger" "6.4.13"
-    "@storybook/store" "6.4.13"
-    "@storybook/theming" "6.4.13"
+    "@storybook/node-logger" "6.4.14"
+    "@storybook/store" "6.4.14"
+    "@storybook/theming" "6.4.14"
     core-js "^3.8.2"
     lodash "^4.17.21"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-docs@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-6.4.13.tgz#7d6990d3afcb4e6334891880ea55da7cab118719"
-  integrity sha512-frsHcZD3jabIXxYkenwigJhAiqmbeBztc1cUTMWSZ9kVDJN6h2msq/vD0LEotfjcvDe3XS2HZgBjdDJ1UUUj/g==
+"@storybook/addon-docs@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-docs/-/addon-docs-6.4.14.tgz#0be1faf6d0b4deae93e37a838a2aae197cead74a"
+  integrity sha512-MIZWfDG80kolo1lOGfMOzQlE3d0I3PBvz04u8v2UMB6k99msC55ZigZcyaKRQs3lwlVM6uUflNVnpTVuTUZNHA==
   dependencies:
     "@babel/core" "^7.12.10"
     "@babel/generator" "^7.12.11"
@@ -1839,21 +1839,21 @@
     "@mdx-js/loader" "^1.6.22"
     "@mdx-js/mdx" "^1.6.22"
     "@mdx-js/react" "^1.6.22"
-    "@storybook/addons" "6.4.13"
-    "@storybook/api" "6.4.13"
-    "@storybook/builder-webpack4" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/components" "6.4.13"
-    "@storybook/core" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/api" "6.4.14"
+    "@storybook/builder-webpack4" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/components" "6.4.14"
+    "@storybook/core" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/csf-tools" "6.4.13"
-    "@storybook/node-logger" "6.4.13"
-    "@storybook/postinstall" "6.4.13"
-    "@storybook/preview-web" "6.4.13"
-    "@storybook/source-loader" "6.4.13"
-    "@storybook/store" "6.4.13"
-    "@storybook/theming" "6.4.13"
+    "@storybook/csf-tools" "6.4.14"
+    "@storybook/node-logger" "6.4.14"
+    "@storybook/postinstall" "6.4.14"
+    "@storybook/preview-web" "6.4.14"
+    "@storybook/source-loader" "6.4.14"
+    "@storybook/store" "6.4.14"
+    "@storybook/theming" "6.4.14"
     acorn "^7.4.1"
     acorn-jsx "^5.3.1"
     acorn-walk "^7.2.0"
@@ -1868,7 +1868,7 @@
     lodash "^4.17.21"
     nanoid "^3.1.23"
     p-limit "^3.1.0"
-    prettier "<=2.3.0"
+    prettier ">=2.2.1 <=2.3.0"
     prop-types "^15.7.2"
     react-element-to-jsx-string "^14.3.4"
     regenerator-runtime "^0.13.7"
@@ -1877,36 +1877,36 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/addon-essentials@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-6.4.13.tgz#9deec5014dcad4ce58c66e5a6f7bf289cea0f10f"
-  integrity sha512-ekvyeVckKkffGQMzp6cT0/Mi8Wo1fqF/DGp3vJIcIrExfvuZa/qi8PoHyx+cr8dfI0b8Jf8Lv7qcLIxNnkA5Bg==
+"@storybook/addon-essentials@latest":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-essentials/-/addon-essentials-6.4.14.tgz#25eea7f148d7decac59565631afa3c755631c169"
+  integrity sha512-ndjVkGRBkCI6Tw/lAHoeD8GmnhRUUpTl2Iv9oiD0AEIpetYl0osfHLqHpMtrgem1Mq6uGiGWNdVhwFnPixkWPg==
   dependencies:
-    "@storybook/addon-actions" "6.4.13"
-    "@storybook/addon-backgrounds" "6.4.13"
-    "@storybook/addon-controls" "6.4.13"
-    "@storybook/addon-docs" "6.4.13"
-    "@storybook/addon-measure" "6.4.13"
-    "@storybook/addon-outline" "6.4.13"
-    "@storybook/addon-toolbars" "6.4.13"
-    "@storybook/addon-viewport" "6.4.13"
-    "@storybook/addons" "6.4.13"
-    "@storybook/api" "6.4.13"
-    "@storybook/node-logger" "6.4.13"
+    "@storybook/addon-actions" "6.4.14"
+    "@storybook/addon-backgrounds" "6.4.14"
+    "@storybook/addon-controls" "6.4.14"
+    "@storybook/addon-docs" "6.4.14"
+    "@storybook/addon-measure" "6.4.14"
+    "@storybook/addon-outline" "6.4.14"
+    "@storybook/addon-toolbars" "6.4.14"
+    "@storybook/addon-viewport" "6.4.14"
+    "@storybook/addons" "6.4.14"
+    "@storybook/api" "6.4.14"
+    "@storybook/node-logger" "6.4.14"
     core-js "^3.8.2"
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-links@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-6.4.13.tgz#fbec1ef4d29a14d6d0dc85c6be473eebad91a31a"
-  integrity sha512-d/uxMZoEjgCRhVvJXYIKJ0VtHARA7p7/oDxBMiexBDGZ2FzZWtq/nejdER539X71JMUkjkaqTs+ekTunZe0eMg==
+"@storybook/addon-links@latest":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-6.4.14.tgz#7dedd5502cf1fecdcfc845e59a10769cb32ec175"
+  integrity sha512-Y+5tdmAdkFzk0OC9wJnHdpVfhq3uqqlrAUFE3QYeof4uL6wLNSr2pl0BzCGQtnTfLs0i0bExXaTP5pZhwSnQoA==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/router" "6.4.13"
+    "@storybook/router" "6.4.14"
     "@types/qs" "^6.9.5"
     core-js "^3.8.2"
     global "^4.4.0"
@@ -1915,94 +1915,94 @@
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-measure@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-6.4.13.tgz#dcf2f3f791f662a35a1331f8133d1c3bae3b823b"
-  integrity sha512-uOnJrSWNlMznScCfeXkhqlenLoz6DBgNgBxuP7P6TiF5cxq7Xwv23RX3Hj1nzybP+wvUPEj08FBCh8BqgGOsOA==
+"@storybook/addon-measure@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-measure/-/addon-measure-6.4.14.tgz#5bd35b12e09f82b0f3dad2e477e26014d5c016e6"
+  integrity sha512-irL4dk9LJopTPPt8ukDyOa453tB8AqRIYGY91Ou2Tr/JvBy2J/KqEZxWoHXQdaIhR+QLi5ShBNEcLxawi+j3tg==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/api" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/components" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/api" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/components" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
     core-js "^3.8.2"
     global "^4.4.0"
 
-"@storybook/addon-outline@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-6.4.13.tgz#891955b0d88de843863d3e5860f29754bc98144b"
-  integrity sha512-9BR70PRQeHtED/NkDp6JPRPrpKA43AubgRu4PHUJ0sbaD7o2DMHPKtt2AcsZoL7JSeGDl30cYzfn3pVZDPVxEA==
+"@storybook/addon-outline@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-outline/-/addon-outline-6.4.14.tgz#a75b29b961717710a1d14e5bf1628affec329053"
+  integrity sha512-7YVOPmqAeFdhJkRlvbhfEphU9UlYPcjwUf5icNhhKiERLSdTyhyI0uY1orhQjgBYztfNs60raZnwmNZ6JElqNQ==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/api" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/components" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/api" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/components" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
     core-js "^3.8.2"
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
-"@storybook/addon-toolbars@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-6.4.13.tgz#c28fb72897709f689cda3675d3c0a4c26a6fe20d"
-  integrity sha512-57/bO5MsVnRjmxff+JjQzqjWCzX1KDHR8zla1RpaGsW5ejXcQumW38Xbp0OCscD7wGLL/b58GM/9OIk38LqBwA==
+"@storybook/addon-toolbars@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-toolbars/-/addon-toolbars-6.4.14.tgz#cfb9b900919c1179747018d02604359d85d3988d"
+  integrity sha512-fB155DH0t0ONsHOTgI0OlbsN4yktCfeOQ0vH4uqzrwqLAxyecs42i0sSPPq1E5/Kn5GMnyrhxEQ9yUoQp/4rBQ==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/api" "6.4.13"
-    "@storybook/components" "6.4.13"
-    "@storybook/theming" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/api" "6.4.14"
+    "@storybook/components" "6.4.14"
+    "@storybook/theming" "6.4.14"
     core-js "^3.8.2"
     regenerator-runtime "^0.13.7"
 
-"@storybook/addon-viewport@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-6.4.13.tgz#0307e7664ef1c791d5f0f28e11e229d2cc7c35c1"
-  integrity sha512-EzgPyLRTDgezSlZ7yCKDhR/VcKBECEdd7JCLiuVbfrThVhaKzM9gCx5pDnc0qTflx0DagqkIWFHNVPQt2KnQ3g==
+"@storybook/addon-viewport@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-6.4.14.tgz#7e0988f9e8348712a334d1fa3df8fe6134d5d9ed"
+  integrity sha512-nlRMrru40SlWQT319NrTuEglPRzYKEkFIC4DFK915RYGf97A1iTVxe33AH9Bck7kT7WAAo0gZmxskxogSBGK7w==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/api" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/components" "6.4.13"
-    "@storybook/core-events" "6.4.13"
-    "@storybook/theming" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/api" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/components" "6.4.14"
+    "@storybook/core-events" "6.4.14"
+    "@storybook/theming" "6.4.14"
     core-js "^3.8.2"
     global "^4.4.0"
     memoizerific "^1.11.3"
     prop-types "^15.7.2"
     regenerator-runtime "^0.13.7"
 
-"@storybook/addons@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.4.13.tgz#df35a7ad908018125eb817ec6a3af05fac09543a"
-  integrity sha512-2oxZ/VOuXUpOvtKGy+fR1FNwyfaTkzKs9I6cZq2zbEGK2q/5x6rtczwNRm5PjK35At+VurMq0E+IHH10JO9vHw==
+"@storybook/addons@6.4.14", "@storybook/addons@latest":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.4.14.tgz#45d6937bc2ece33ceadc5358b2a2298d2a0d1e95"
+  integrity sha512-Snu42ejLyBAh6PWdlrdI72HKN1oKY7q0R9qEID2wk953WrqgGu4URakp14YLxghJCyKTSfGPs6LNZRRI6H5xgA==
   dependencies:
-    "@storybook/api" "6.4.13"
-    "@storybook/channels" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/api" "6.4.14"
+    "@storybook/channels" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/router" "6.4.13"
-    "@storybook/theming" "6.4.13"
+    "@storybook/router" "6.4.14"
+    "@storybook/theming" "6.4.14"
     "@types/webpack-env" "^1.16.0"
     core-js "^3.8.2"
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/api@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.4.13.tgz#bf5ced25a31c4c76432fd57a133406f8e2a1ce45"
-  integrity sha512-Hr5/dL4tLnQPjrUlVdhsYMSAuJmsZcu3jdfqpjbsDC9S2HNaVtyHGBhQ33jD8+xtXoorsuS7t4SfWzLOgPPflg==
+"@storybook/api@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.4.14.tgz#a477646f7e020a362f044d2e614e3d1a86ba8f6f"
+  integrity sha512-GGGwB5+EquoausTXYx4dnLBBk2sOiS1Z58mDj0swBXCZdjfyUfLyxjxvvb/hl65ltufWP3IdmlKKaLiuARXNtw==
   dependencies:
-    "@storybook/channels" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/channels" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/router" "6.4.13"
+    "@storybook/router" "6.4.14"
     "@storybook/semver" "^7.3.2"
-    "@storybook/theming" "6.4.13"
+    "@storybook/theming" "6.4.14"
     core-js "^3.8.2"
     fast-deep-equal "^3.1.3"
     global "^4.4.0"
@@ -2014,10 +2014,10 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/builder-webpack4@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack4/-/builder-webpack4-6.4.13.tgz#529087b9d64c3634e237f0a837f97fe1db4a564a"
-  integrity sha512-Vjvje/XpFirVY6bOU+ahS2niapjA0Qams5jBE8YnPUhbigqsLOMMpnJ+C505xC6S5VW0lMkhJpCQ1NQyva3sRw==
+"@storybook/builder-webpack4@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-webpack4/-/builder-webpack4-6.4.14.tgz#77f45d164f5b93776fa154252706c6b73bd0edc5"
+  integrity sha512-hRzwdNNLxuyb0XPpvbTSkQuqG2frhog2SsjgPVXorsSMPr95owo9Nq9hp+TnywpvaR9lrPlESzhhv2sSR3blTw==
   dependencies:
     "@babel/core" "^7.12.10"
     "@babel/plugin-proposal-class-properties" "^7.12.1"
@@ -2040,22 +2040,22 @@
     "@babel/preset-env" "^7.12.11"
     "@babel/preset-react" "^7.12.10"
     "@babel/preset-typescript" "^7.12.7"
-    "@storybook/addons" "6.4.13"
-    "@storybook/api" "6.4.13"
-    "@storybook/channel-postmessage" "6.4.13"
-    "@storybook/channels" "6.4.13"
-    "@storybook/client-api" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/components" "6.4.13"
-    "@storybook/core-common" "6.4.13"
-    "@storybook/core-events" "6.4.13"
-    "@storybook/node-logger" "6.4.13"
-    "@storybook/preview-web" "6.4.13"
-    "@storybook/router" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/api" "6.4.14"
+    "@storybook/channel-postmessage" "6.4.14"
+    "@storybook/channels" "6.4.14"
+    "@storybook/client-api" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/components" "6.4.14"
+    "@storybook/core-common" "6.4.14"
+    "@storybook/core-events" "6.4.14"
+    "@storybook/node-logger" "6.4.14"
+    "@storybook/preview-web" "6.4.14"
+    "@storybook/router" "6.4.14"
     "@storybook/semver" "^7.3.2"
-    "@storybook/store" "6.4.13"
-    "@storybook/theming" "6.4.13"
-    "@storybook/ui" "6.4.13"
+    "@storybook/store" "6.4.14"
+    "@storybook/theming" "6.4.14"
+    "@storybook/ui" "6.4.14"
     "@types/node" "^14.0.10"
     "@types/webpack" "^4.41.26"
     autoprefixer "^9.8.6"
@@ -2089,51 +2089,51 @@
     webpack-hot-middleware "^2.25.1"
     webpack-virtual-modules "^0.2.2"
 
-"@storybook/channel-postmessage@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.4.13.tgz#e299a75db2e572662b9bd7f92bc9eedd2df51dd9"
-  integrity sha512-fyju7H/t2oDp9yci6KImRDPr9FnGV6B0juJ+2kEtVAmeDo55BScjT96SQuS/uk4c0wo6NZMrCt6HiC4zOmrD6g==
+"@storybook/channel-postmessage@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.4.14.tgz#ce719041768ea8c0d64b7edc32ec7c774fba9b19"
+  integrity sha512-z+fBi/eAAswELWOdlIFI9XXNjyxfguKyqKGSQ7qdz3eFyxeuWnxTa9aZsnLIXpPKY9QPydpBSJcIKUCdN6DbIg==
   dependencies:
-    "@storybook/channels" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/channels" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     core-js "^3.8.2"
     global "^4.4.0"
     qs "^6.10.0"
     telejson "^5.3.2"
 
-"@storybook/channel-websocket@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/channel-websocket/-/channel-websocket-6.4.13.tgz#6a85b6c846097f3a601038dcd58e8f624a9a3600"
-  integrity sha512-edc/KRF2dpMyCI67ik8loo2cNh7TUP8HoO/YJBVPTEGmOQxMWgmYs+loTd1xoZAFBdkVKvLXBiu8umPpdh2MpA==
+"@storybook/channel-websocket@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-websocket/-/channel-websocket-6.4.14.tgz#d71a4c8a4b36e2e89a4a3c56af3e0aa50353e02f"
+  integrity sha512-4Y6TDeYLzItGIaYKo3s6xxSmUF11j96dOX7n74ax45zcMhpp/XwG5i0FU1DtGb5PnhPxg+vJmKa1IgizzaWRYg==
   dependencies:
-    "@storybook/channels" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
+    "@storybook/channels" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
     core-js "^3.8.2"
     global "^4.4.0"
     telejson "^5.3.2"
 
-"@storybook/channels@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.4.13.tgz#d79005f712be7575be093d917c13f3a0033bb44d"
-  integrity sha512-QWvm2TiqPZVPQLBq7ETcABNi17HIhNaXhJJUyNFBBXFtAHcbzMRFEBi6gkCVXK7QdtFo3Z68TU5htDkwjYVerg==
+"@storybook/channels@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.4.14.tgz#f7a5416c971febd26ed7b03a75d99fd819790e48"
+  integrity sha512-3QOVxFG6ZAxDXCta1ie4SUPQ3s50yHeuZzVg6uPp+DcC1FrXeDFYBcU9t0j/jrSgbeKcnFHWxmRHNy1BRyWv/A==
   dependencies:
     core-js "^3.8.2"
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/client-api@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-6.4.13.tgz#7cc59353a1329a6e9fca7247ae255d5ebceb80a4"
-  integrity sha512-YoF0iKeOTv06HFTLSg1M8Fs9JZwFcNhGFHXv7/LtuTZ9n6ATgaZm7eTTdKrn1d8Qjxql7c7Lm/7mdZgus9ByBA==
+"@storybook/client-api@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-6.4.14.tgz#d2053511971e06d70bba2accfbd1f6c0f2084e2a"
+  integrity sha512-hqdgE0zKVhcqG/8t/veJRgjsOT076LeKxoA+w2Ga4iU+reIGui/GvLsjvyFFTyOMHVeo2Ze4LW63oTYKF/I5iQ==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/channel-postmessage" "6.4.13"
-    "@storybook/channels" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/channel-postmessage" "6.4.14"
+    "@storybook/channels" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/store" "6.4.13"
+    "@storybook/store" "6.4.14"
     "@types/qs" "^6.9.5"
     "@types/webpack-env" "^1.16.0"
     core-js "^3.8.2"
@@ -2148,23 +2148,23 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/client-logger@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.4.13.tgz#2467ee13c7f85e9f6c0d9cd64c11ee7a109b060a"
-  integrity sha512-VPrrgJRURztXAKTeHOpzKMAHnNupkGApUDNlPIs0Qxyn5gaSiy806q4XPoROno3mVgEe+7Chf86hRiL8pJnlCA==
+"@storybook/client-logger@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.4.14.tgz#a7aed982407e4146548f9ac4b3af5eba24cd045e"
+  integrity sha512-4VmFWZxhpeiG5fDhfqAyQbCfXZSBKS4fNKf35ABWiHStZRDndxml8K5WFtmOmMvVzjrGQx8HesenYMawK6xo/Q==
   dependencies:
     core-js "^3.8.2"
     global "^4.4.0"
 
-"@storybook/components@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.4.13.tgz#2e7f109ecef63ae0c6f096939d69e26abbb39c6b"
-  integrity sha512-edeoYycQMsPaXPyPvYV4Aoiz4A/9kPsZt0Wf2zBGMGX6cpaGV3aoy8pFBl6XSq2hPxIn8JdcB/8MK3/tj35h4w==
+"@storybook/components@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.4.14.tgz#546b34fe3feb09e670b76ff71d889bf5f566f1e4"
+  integrity sha512-M7unerbOnvg+UN7qPxBCBWzK/boVdSSQxRiPAr1OL3M4OyEU8+TNPdQeAG0aF4zqtU0BrsDf4E85EznoMXUiFQ==
   dependencies:
     "@popperjs/core" "^2.6.0"
-    "@storybook/client-logger" "6.4.13"
+    "@storybook/client-logger" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/theming" "6.4.13"
+    "@storybook/theming" "6.4.14"
     "@types/color-convert" "^2.0.0"
     "@types/overlayscrollbars" "^1.12.0"
     "@types/react-syntax-highlighter" "11.0.5"
@@ -2186,21 +2186,21 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/core-client@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/core-client/-/core-client-6.4.13.tgz#c25a6f5916f9642c64a9f2aeb9f5f7cee12b053a"
-  integrity sha512-1m7cAlF16mtVdSNmP8a4z00GCkw2dMyUyJX8snzgYGLD5FaqPLyNGJIidqllHsBUXBfEL2FSu+E9QygK12+O1w==
+"@storybook/core-client@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/core-client/-/core-client-6.4.14.tgz#8f5dc6fe2295e479225bd396404a43679a15637e"
+  integrity sha512-e9pzKz52DVhmo8+sUEDvagwGKVqWZ6NQBIt3mBvd79/zXTPkFRnSVitOyYErqhgN1kuwocTg+2BigRr3H0qXaQ==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/channel-postmessage" "6.4.13"
-    "@storybook/channel-websocket" "6.4.13"
-    "@storybook/client-api" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/channel-postmessage" "6.4.14"
+    "@storybook/channel-websocket" "6.4.14"
+    "@storybook/client-api" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/preview-web" "6.4.13"
-    "@storybook/store" "6.4.13"
-    "@storybook/ui" "6.4.13"
+    "@storybook/preview-web" "6.4.14"
+    "@storybook/store" "6.4.14"
+    "@storybook/ui" "6.4.14"
     airbnb-js-shims "^2.2.1"
     ansi-to-html "^0.6.11"
     core-js "^3.8.2"
@@ -2212,10 +2212,10 @@
     unfetch "^4.2.0"
     util-deprecate "^1.0.2"
 
-"@storybook/core-common@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-6.4.13.tgz#019ce8089d5f3a96c436f208962fbf711ccf8e5c"
-  integrity sha512-KoFa4yktuqWsW+/O6uc7iba25X9eKhp80l9tHsa1RWE94mQdCBUo5VsNoe35JvqFSDOspQ+brCe6vBUaIYe+cQ==
+"@storybook/core-common@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/core-common/-/core-common-6.4.14.tgz#137b935855f0cc785ec55b386312747949e30e99"
+  integrity sha512-7NRmtcY2INmobsmUUX4afO78RHpyQMO8vboy6H8HRtfcw6fy4zaHoCb7gZZfvvn8gtBWNmwip8I9XK5BpRrh3Q==
   dependencies:
     "@babel/core" "^7.12.10"
     "@babel/plugin-proposal-class-properties" "^7.12.1"
@@ -2238,7 +2238,7 @@
     "@babel/preset-react" "^7.12.10"
     "@babel/preset-typescript" "^7.12.7"
     "@babel/register" "^7.12.1"
-    "@storybook/node-logger" "6.4.13"
+    "@storybook/node-logger" "6.4.14"
     "@storybook/semver" "^7.3.2"
     "@types/node" "^14.0.10"
     "@types/pretty-hrtime" "^1.0.0"
@@ -2267,29 +2267,29 @@
     util-deprecate "^1.0.2"
     webpack "4"
 
-"@storybook/core-events@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.4.13.tgz#caf1adafd743f8d53a151bc402449f841896cb9c"
-  integrity sha512-zNlzNv7qVXjLf7yfvY9KfLvDY8nVskxrjmz0+21rIqUefS9+7SWBrtJJURpCaoPf/BmACqh/6c1RnuOY7TESnw==
+"@storybook/core-events@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.4.14.tgz#37293c0fce703f2643cec6f24fc6ef7c40e30ded"
+  integrity sha512-9QFltg2mxTDjMBfmVtFHtrAEPY/i0oVp2kVdTWo6g05cPffYKAjNUnUVjUl7yiqcQmdEcdqUUQ0ut3xgmcYi/A==
   dependencies:
     core-js "^3.8.2"
 
-"@storybook/core-server@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-6.4.13.tgz#cbc11d442a8be6f06929c8d655e9b752204ebca9"
-  integrity sha512-i3zrtHHkV6/b+jJF65BQu+YuXen+T/MF1f5J+li5nvJnLKhssVQmvpGvWyJezT3OgFkC1+BFBokFY6NXHHw77g==
+"@storybook/core-server@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/core-server/-/core-server-6.4.14.tgz#0bef36e1203eb56e1c9bbf7f02122500c8f7d534"
+  integrity sha512-SzO8SaLTZ36Q4PNhJD4XJjlnonbR2Os0gzTknDBbwyIRPUtFUdk6isSG14RM5yYWPM0QQIs9og5ztSPX58YZlw==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.3"
-    "@storybook/builder-webpack4" "6.4.13"
-    "@storybook/core-client" "6.4.13"
-    "@storybook/core-common" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/builder-webpack4" "6.4.14"
+    "@storybook/core-client" "6.4.14"
+    "@storybook/core-common" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/csf-tools" "6.4.13"
-    "@storybook/manager-webpack4" "6.4.13"
-    "@storybook/node-logger" "6.4.13"
+    "@storybook/csf-tools" "6.4.14"
+    "@storybook/manager-webpack4" "6.4.14"
+    "@storybook/node-logger" "6.4.14"
     "@storybook/semver" "^7.3.2"
-    "@storybook/store" "6.4.13"
+    "@storybook/store" "6.4.14"
     "@types/node" "^14.0.10"
     "@types/node-fetch" "^2.5.7"
     "@types/pretty-hrtime" "^1.0.0"
@@ -2322,18 +2322,18 @@
     webpack "4"
     ws "^8.2.3"
 
-"@storybook/core@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-6.4.13.tgz#a317df48d72cb4e7ac9fda6f935be7b2d67f5877"
-  integrity sha512-OSbji5w4jrGNALbxJwktZhi8qw4bGgL88dL72O40173b8ROLBOGkEkkz/BpHbqx2PhS9sGVNVMK2b2BwAiiu7g==
+"@storybook/core@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/core/-/core-6.4.14.tgz#c20a1432f22603eb2d3523389ff1311fffbba24f"
+  integrity sha512-41WNDXKMZuCKnvbLBBYCd1+ip4uJ4AGeCOhmp/KZK7TgkitJ0JrvyRgnbpXR8bAMiOv2Hh9t9Vmi5D3QZ8COlg==
   dependencies:
-    "@storybook/core-client" "6.4.13"
-    "@storybook/core-server" "6.4.13"
+    "@storybook/core-client" "6.4.14"
+    "@storybook/core-server" "6.4.14"
 
-"@storybook/csf-tools@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-6.4.13.tgz#393b19f3901784d7c820abbe7379977e7ec5f15c"
-  integrity sha512-eEYQdr/N4bsiQFxNEUkfQ/KyqdnUecwFS7V1k16/m/dP7cfinwW2Yo+9t77uWe3Qmzj9RbM6jrdWxXEUZ6MwvQ==
+"@storybook/csf-tools@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-tools/-/csf-tools-6.4.14.tgz#c5112e17f07dae4c7b922aefd45dccbbc9e49803"
+  integrity sha512-mRFsIhzFA2JBeUqdvl6+WM6HmHXaWGLbCgalzGqX65i1pSvhmC3jHh0OTTypMj9XneWH6/cHQh7LvivYbjJ8Cg==
   dependencies:
     "@babel/core" "^7.12.10"
     "@babel/generator" "^7.12.11"
@@ -2349,7 +2349,7 @@
     global "^4.4.0"
     js-string-escape "^1.0.1"
     lodash "^4.17.21"
-    prettier "<=2.3.0"
+    prettier ">=2.2.1 <=2.3.0"
     regenerator-runtime "^0.13.7"
     ts-dedent "^2.0.0"
 
@@ -2360,20 +2360,20 @@
   dependencies:
     lodash "^4.17.15"
 
-"@storybook/manager-webpack4@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/manager-webpack4/-/manager-webpack4-6.4.13.tgz#69d6d60818192dc18d6b2dee9548482e8abf6a54"
-  integrity sha512-aUUIvSf1nUSuPEdLFcbXbEbm+WlBrpX+Ce+Ee5zuMpggfiMeq4H4UB5QuluB8oLUcJA/ZoQZ9m4pPfUZDH0O0w==
+"@storybook/manager-webpack4@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/manager-webpack4/-/manager-webpack4-6.4.14.tgz#b8ca3a11d0fb18ef6ca3e58e1c36b2eb8226ccbf"
+  integrity sha512-j565G7vZLBXK60J1hiZhbeZ6K48y8CMMZCcIihqsFv/4jj0kI3Ba4IhCrOkHiqiRM89mRu5/Ga3DnHTBvIYIEA==
   dependencies:
     "@babel/core" "^7.12.10"
     "@babel/plugin-transform-template-literals" "^7.12.1"
     "@babel/preset-react" "^7.12.10"
-    "@storybook/addons" "6.4.13"
-    "@storybook/core-client" "6.4.13"
-    "@storybook/core-common" "6.4.13"
-    "@storybook/node-logger" "6.4.13"
-    "@storybook/theming" "6.4.13"
-    "@storybook/ui" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/core-client" "6.4.14"
+    "@storybook/core-common" "6.4.14"
+    "@storybook/node-logger" "6.4.14"
+    "@storybook/theming" "6.4.14"
+    "@storybook/ui" "6.4.14"
     "@types/node" "^14.0.10"
     "@types/webpack" "^4.41.26"
     babel-loader "^8.0.0"
@@ -2402,10 +2402,10 @@
     webpack-dev-middleware "^3.7.3"
     webpack-virtual-modules "^0.2.2"
 
-"@storybook/node-logger@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-6.4.13.tgz#67f294e56b5014c81dde542940f9a17f7d74604a"
-  integrity sha512-L0WJjJ3MTkdSpCaC1xSJ1/SJzblQ8E3tYKSI3M3890711gfxtSM/9CfuatQ6ibTXcm5d8bW6TUJayTD4I8vUPg==
+"@storybook/node-logger@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-6.4.14.tgz#2e96f4e3e06c78c3d065e59818515209122d9ae4"
+  integrity sha512-mowC0adx4hLtCqGMQKRfNmiRYAL2PYdk3ojc91qzIKNrjSYnE4U8d9qlw5WLx1PKEnZVji3+QiYfNHpA/8PoKw==
   dependencies:
     "@types/npmlog" "^4.1.2"
     chalk "^4.1.0"
@@ -2413,24 +2413,24 @@
     npmlog "^5.0.1"
     pretty-hrtime "^1.0.3"
 
-"@storybook/postinstall@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-6.4.13.tgz#508f73e0a2f07ba994554d43daad0f6b49945ffa"
-  integrity sha512-7SzFt0BDFOI0vFKc0Ba5slkQaur3AEN9211U7pBbzgp6HxBjiTT5fqLET+dvk30ke8YtOauj0LZ+uHx9TNYrBA==
+"@storybook/postinstall@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/postinstall/-/postinstall-6.4.14.tgz#e8f7925529d4955783660f409deee1e907897b2b"
+  integrity sha512-nLHV+BdDKFAZWU1CA/o3zRCNT3+tVWesERqkO9kJLURwqHkfU1yyv5WNILyUsvlwwJCFdDOEdXupC1RR7E6Gkg==
   dependencies:
     core-js "^3.8.2"
 
-"@storybook/preview-web@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/preview-web/-/preview-web-6.4.13.tgz#14b9e106f3cc00dd411a43be9cd280e5e8a0ecfc"
-  integrity sha512-z21N09iWrzi2sX5+06aNvxPVp0rzntO7seM7zIPxqpFiEsAoPodkVJka3YyJpgK3S2JtgipmIgvLJeLXENLr3g==
+"@storybook/preview-web@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/preview-web/-/preview-web-6.4.14.tgz#4d7035d5aa0e8c41c9a2ff21c2a3b3cbae9f3688"
+  integrity sha512-3E++OYz+OCyJBIchkNCJRtxEU7XNDBdIvKRTCx48X+Uv5qoLeCpXiXOSK/42LlraWZkfBs56yHv9VSqJoQ8VwA==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/channel-postmessage" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/channel-postmessage" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/store" "6.4.13"
+    "@storybook/store" "6.4.14"
     ansi-to-html "^0.6.11"
     core-js "^3.8.2"
     global "^4.4.0"
@@ -2455,22 +2455,22 @@
     react-docgen-typescript "^2.0.0"
     tslib "^2.0.0"
 
-"@storybook/react@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-6.4.13.tgz#f51f2c56dd57554dbb53fdbfd0b5a20a3ad914b8"
-  integrity sha512-bmHGeAAad0qoEfselx3qvWlPf1fWccDgki3TneFWYTSoybZOuu0PWJp+M7kqWMxcyvdwQImjA9F+vCc7CUuF9w==
+"@storybook/react@latest":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/react/-/react-6.4.14.tgz#7be241ecfa412312681bb54c82327764d70ffb70"
+  integrity sha512-wlPjE5Xcarc5NTgnHchvGE56EVYioAyRZoYvb/YyiCX1+A8sQkwS2qTTH8e/pdG539A4NMrciMosvjvEPZcEvg==
   dependencies:
     "@babel/preset-flow" "^7.12.1"
     "@babel/preset-react" "^7.12.10"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.1"
-    "@storybook/addons" "6.4.13"
-    "@storybook/core" "6.4.13"
-    "@storybook/core-common" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/core" "6.4.14"
+    "@storybook/core-common" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
-    "@storybook/node-logger" "6.4.13"
+    "@storybook/node-logger" "6.4.14"
     "@storybook/react-docgen-typescript-plugin" "1.0.2-canary.253f8c1.0"
     "@storybook/semver" "^7.3.2"
-    "@storybook/store" "6.4.13"
+    "@storybook/store" "6.4.14"
     "@types/webpack-env" "^1.16.0"
     babel-plugin-add-react-displayname "^0.0.5"
     babel-plugin-named-asset-import "^0.3.1"
@@ -2485,12 +2485,12 @@
     ts-dedent "^2.0.0"
     webpack "4"
 
-"@storybook/router@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.4.13.tgz#f83dc12b21906f9a671d4e963cac747972d848c7"
-  integrity sha512-6KbIpSL8QhGglzGb+tWTvAF/2EVpmgwlU5VP6Xs3GANcOc3VeXWl1fcJD6CNPp2DHwjkblW+21dcoHqfljnTmg==
+"@storybook/router@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.4.14.tgz#46fd46eadafc0d6b647be13702704c5fcf8f11e3"
+  integrity sha512-5+tePyINtwPYm4izgOBZ2sX2ViWtfmmO2vwOAPlWWEGzsRosVQsGMdZv1R8rk4Jl/TotMjlTmd8I1/BufEeIeQ==
   dependencies:
-    "@storybook/client-logger" "6.4.13"
+    "@storybook/client-logger" "6.4.14"
     core-js "^3.8.2"
     fast-deep-equal "^3.1.3"
     global "^4.4.0"
@@ -2510,30 +2510,30 @@
     core-js "^3.6.5"
     find-up "^4.1.0"
 
-"@storybook/source-loader@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-6.4.13.tgz#ba7b379148885eb53c838e520c7b4882c82e891b"
-  integrity sha512-3M2VRt/ABGpm2G9MxkWAufvacPFDdHl+gvkNOq4lRhFw8uAh78xoXb1n0heOOuYGtJbw1+UHNOh4ahZGCWYxJg==
+"@storybook/source-loader@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/source-loader/-/source-loader-6.4.14.tgz#d1e6c2df0918e4867b3e4b5ce748685938f77d87"
+  integrity sha512-3hqVTK5+rQFK7Jf6/jYO/24daYIMn9L1vCAo9xSFgy999OMw7967ZmVMGMgVkOh7GQSZmzt3kMonv4bDmIGJMw==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
     core-js "^3.8.2"
     estraverse "^5.2.0"
     global "^4.4.0"
     loader-utils "^2.0.0"
     lodash "^4.17.21"
-    prettier "<=2.3.0"
+    prettier ">=2.2.1 <=2.3.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/store@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/store/-/store-6.4.13.tgz#afeccc2dfe0126208d869da199f702635858c1e5"
-  integrity sha512-VUDYwn1PHTa92kaJFCWqP+QS5wsHO9us2prhHnD7k9qvvQrbxD2DewtGxdT7cRHbZI8jY5CiqMVKilZRaXSM3Q==
+"@storybook/store@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/store/-/store-6.4.14.tgz#2ec5601e1c40a27f164b570d4c2b84c57d3a4115"
+  integrity sha512-D9KoJuNvwb9mEQD60GTPYSbQuXWZQHE8RBxCq7d7Qu46mrhlsNTOwt09lIgmuM3jAVto3FxnXY4U81RwJza7tg==
   dependencies:
-    "@storybook/addons" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/core-events" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/core-events" "6.4.14"
     "@storybook/csf" "0.0.2--canary.87bc651.0"
     core-js "^3.8.2"
     fast-deep-equal "^3.1.3"
@@ -2547,15 +2547,15 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/theming@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.4.13.tgz#1a8aadeddb6c3a115f739aa1a4bbd7e65d4a3830"
-  integrity sha512-oWRoNnvO4QnRnplZ74DVdU4k91eqw8y0Xqn6lzZBeC8hq6mYWldgfj1LZ24gJhVtEIa7ZKoyujGUygHaH8WXHw==
+"@storybook/theming@6.4.14", "@storybook/theming@latest":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.4.14.tgz#f034914eb1853a80f588c7c141d47af0595f6d1f"
+  integrity sha512-kqmXNnIoOSAS4cgr9PitMgVrOps725O99eTsJNxB6J1Ide0CsA5v2tV6AmQn/scnpCQNr8uSjZerNlEcl/ensg==
   dependencies:
     "@emotion/core" "^10.1.1"
     "@emotion/is-prop-valid" "^0.8.6"
     "@emotion/styled" "^10.0.27"
-    "@storybook/client-logger" "6.4.13"
+    "@storybook/client-logger" "6.4.14"
     core-js "^3.8.2"
     deep-object-diff "^1.1.0"
     emotion-theming "^10.0.27"
@@ -2565,21 +2565,21 @@
     resolve-from "^5.0.0"
     ts-dedent "^2.0.0"
 
-"@storybook/ui@6.4.13":
-  version "6.4.13"
-  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-6.4.13.tgz#79e04f988ca537a4c350fe470ad7c14392794b8b"
-  integrity sha512-EvpWk2iHjfiWkuMuzYz5fXl4r7S9Q80EtFFVkaBEZfIoKjvIkxppGQ3kz892ZdXzuazzvni2qcb7OJA9S7AgLw==
+"@storybook/ui@6.4.14":
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/@storybook/ui/-/ui-6.4.14.tgz#59f08ac8d8eb782fa13fc9a8dd715222c96bf234"
+  integrity sha512-nZsd8GXzYwmmTjZUB7pJMh+Q1fST0d2lFkhDHakxLaPLwumibw9NHJ7bRWYHFlAVYpD0c2+POP3FpOW5Bjby1A==
   dependencies:
     "@emotion/core" "^10.1.1"
-    "@storybook/addons" "6.4.13"
-    "@storybook/api" "6.4.13"
-    "@storybook/channels" "6.4.13"
-    "@storybook/client-logger" "6.4.13"
-    "@storybook/components" "6.4.13"
-    "@storybook/core-events" "6.4.13"
-    "@storybook/router" "6.4.13"
+    "@storybook/addons" "6.4.14"
+    "@storybook/api" "6.4.14"
+    "@storybook/channels" "6.4.14"
+    "@storybook/client-logger" "6.4.14"
+    "@storybook/components" "6.4.14"
+    "@storybook/core-events" "6.4.14"
+    "@storybook/router" "6.4.14"
     "@storybook/semver" "^7.3.2"
-    "@storybook/theming" "6.4.13"
+    "@storybook/theming" "6.4.14"
     copy-to-clipboard "^3.3.1"
     core-js "^3.8.2"
     core-js-pure "^3.8.2"
@@ -8991,7 +8991,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@<=2.3.0:
+"prettier@>=2.2.1 <=2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
   integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,9 +1044,9 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.1.2":
-  version "7.16.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
-  integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
+  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1234,297 +1234,300 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fluentui/keyboard-keys@9.0.0-alpha.5":
-  version "9.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@fluentui/keyboard-keys/-/keyboard-keys-9.0.0-alpha.5.tgz#75b1180e64cd35e5fdeecd116384f772b7bb4ca6"
-  integrity sha512-BdbrE6gOZTZetxrv4eVeBRnePRsLALtbKBm4xflM6xIp3D6HIkP/fxwZicf00L+jv9zHv9o85eSRtVFQEXenAg==
+"@fluentui/keyboard-keys@9.0.0-beta.1":
+  version "9.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/keyboard-keys/-/keyboard-keys-9.0.0-beta.1.tgz#bee2b6b8c20c940242b6c8c885201dfbb870945e"
+  integrity sha512-eGKEzdyIep7KZPoKwHVfcDR3hKuSnI0iDqZGYrIOVWYVr1aD9uZ3JXFK2ad8DZtOGnxgK3/pOvAfqFo61LoRjQ==
 
-"@fluentui/make-styles@9.0.0-alpha.35":
-  version "9.0.0-alpha.35"
-  resolved "https://registry.yarnpkg.com/@fluentui/make-styles/-/make-styles-9.0.0-alpha.35.tgz#80dcde4d7477d4d270fab06225e73821b8273f1f"
-  integrity sha512-RaiYcr1EgXrhtkGKfkdCU9yS+aYmNdHX5t1MjGrZ6TGNZ2AfUFn1EM1KLD/NUOzprgeTnRMn8V2DLoyLZvtjxA==
+"@fluentui/make-styles@9.0.0-beta.3":
+  version "9.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@fluentui/make-styles/-/make-styles-9.0.0-beta.3.tgz#d5916c44ea03413636eb1edcc2ad095a1c63882b"
+  integrity sha512-Bwe3BTLC5ATNcQdUk0U4s+eKU7OlV0UF4dlVjnlNYQefMfTWfr/ozZa3IczATOfYKyYPad1KOM3SBUojUdaoog==
   dependencies:
     "@emotion/hash" "^0.8.0"
     csstype "^2.6.7"
     inline-style-expand-shorthand "^1.2.0"
-    rtl-css-js "^1.14.1"
+    rtl-css-js "^1.14.5"
     stylis "^4.0.6"
     tslib "^2.1.0"
 
-"@fluentui/react-accordion@9.0.0-alpha.90":
-  version "9.0.0-alpha.90"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-accordion/-/react-accordion-9.0.0-alpha.90.tgz#ef70687bee9fb2fb844dbee929f06f4de21e6af7"
-  integrity sha512-aVa76bH4mVYYHtUom7klGZLIJykewLYJrrJZp/ALOtoqg+pKqpReJWMTOax+ZJ2qTqR6B0lTPyJMH9B+FQwgOQ==
+"@fluentui/react-accordion@9.0.0-beta.5":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-accordion/-/react-accordion-9.0.0-beta.5.tgz#cee4fc917f404166f5f9d5c4905fb84f1dd323fb"
+  integrity sha512-KY0g66dnlwl0EVGLVulkujZ3HKhjbdVn2aQO3QNV551+ZcLPB2Y6cCcdLlXnOxR5GAcfvIQ2Ux+QBOYFZks/Iw==
   dependencies:
-    "@fluentui/react-aria" "9.0.0-alpha.45"
-    "@fluentui/react-context-selector" "9.0.0-alpha.39"
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-tabster" "9.0.0-alpha.73"
-    "@fluentui/react-theme" "9.0.0-alpha.26"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-aria" "9.0.0-beta.4"
+    "@fluentui/react-context-selector" "9.0.0-beta.4"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-tabster" "9.0.0-beta.5"
+    "@fluentui/react-theme" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-aria@9.0.0-alpha.45":
-  version "9.0.0-alpha.45"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-aria/-/react-aria-9.0.0-alpha.45.tgz#d3f825836d3cc965ac473f66a76d2e56334e339d"
-  integrity sha512-iKhPM4mh/kllUBiEIugFVXUcNqbap1sQiGd1giF1QEjNRIzZXih35b51hKVGDDzcANvJU18PCOCCNb9MELnq0Q==
+"@fluentui/react-aria@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-aria/-/react-aria-9.0.0-beta.4.tgz#cb06f440a834e344781c5609b0a031ba9df165cd"
+  integrity sha512-5ImpU5S4tOAzkl+GlCeL8r4eDV/1pDYJjA8UlF/d+fYi6bsul4LhoXvdyPWZNZ9O563gtnQT096ChMZlORTbxA==
   dependencies:
-    "@fluentui/keyboard-keys" "9.0.0-alpha.5"
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/keyboard-keys" "9.0.0-beta.1"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-avatar@9.0.0-alpha.93":
-  version "9.0.0-alpha.93"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-avatar/-/react-avatar-9.0.0-alpha.93.tgz#ee4e58496ee588dd9782670a86f012e5fb909100"
-  integrity sha512-UyVGAWX6t33wogKjCSnTQCFCVy4+IFG7C4iJuGB9ikfcvkQFMIYA/SaOepPWkPunS7JS7xnsgztnC/iuWDmwIw==
+"@fluentui/react-avatar@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-avatar/-/react-avatar-9.0.0-beta.4.tgz#2859afa07ea83684aa46e9733cadf27dac365af7"
+  integrity sha512-1VVasWKxr5KBguHfcwDLwKjqSrKsFo3bvkRA2bMGdjNKusElR1SuzzsxEuUEiuzNGKkqIxKVnX+zSzHJC1l6Gg==
   dependencies:
-    "@fluentui/react-badge" "9.0.0-alpha.92"
-    "@fluentui/react-icons" "^1.1.140"
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-theme" "9.0.0-alpha.26"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-badge" "9.0.0-beta.4"
+    "@fluentui/react-icons" "^2.0.152-beta.3"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-theme" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-badge@9.0.0-alpha.92":
-  version "9.0.0-alpha.92"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-badge/-/react-badge-9.0.0-alpha.92.tgz#5c93692cef555fc296595ccf57ec939683bbec65"
-  integrity sha512-IW/Domqi85zAuz+xqXIFQeFH6WXX2FG1gP02NibV3vemlmPB+YhgfwoJVFBZL2cqzIM6AxlJh107mk49hDxXSQ==
+"@fluentui/react-badge@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-badge/-/react-badge-9.0.0-beta.4.tgz#2e26a698ffa5daa0f5452a787775f18e2e5205fa"
+  integrity sha512-FgkHmGumu/GrpXett38ychLQpTHDoI+0uDzdRvvUjmKW7q+RQhIifH4ulXzAbH62v4HrALEMUgoguSdnpitUBA==
   dependencies:
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-theme" "9.0.0-alpha.26"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-icons" "^2.0.152-beta.3"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-theme" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-button@9.0.0-alpha.101":
-  version "9.0.0-alpha.101"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-button/-/react-button-9.0.0-alpha.101.tgz#7038b8a8d7d2f15702a4d6a02ef9c226329694f5"
-  integrity sha512-YXplmdxcOWBYQIZAbC+v8ricQ9We9vRDI3XbBSNgJzn04TAIi5OlF8dlmWOpOkeG5bupvWvn0nC8JYmG8BNEdA==
+"@fluentui/react-button@9.0.0-beta.5":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-button/-/react-button-9.0.0-beta.5.tgz#d57e8b2d94106888a2c2b7cfe867120c6bc5eae9"
+  integrity sha512-ViUaUVhJlqSUdhla4lLaBpMmzf5UC1Wi2H6qKGA3tawUN6pxBf2Ea29bOghiDjsvJKkaDNaGaxj7PQGgr7nEVg==
   dependencies:
-    "@fluentui/keyboard-keys" "9.0.0-alpha.5"
-    "@fluentui/react-aria" "9.0.0-alpha.45"
-    "@fluentui/react-icons" "^1.1.140"
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-tabster" "9.0.0-alpha.73"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/keyboard-keys" "9.0.0-beta.1"
+    "@fluentui/react-aria" "9.0.0-beta.4"
+    "@fluentui/react-icons" "^2.0.152-beta.3"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-tabster" "9.0.0-beta.5"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-card@9.0.0-alpha.18":
-  version "9.0.0-alpha.18"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-card/-/react-card-9.0.0-alpha.18.tgz#a501ef5ae76d61572861f686d3c91ea51ad0a067"
-  integrity sha512-R2UxY4z0itgyNTyk61uvBhqneNxWPl/5Ci4VcwC8NHkXBkgcGUJ48a3ryS5+EZL9QJq0j8UFBlmyGlbLi1ZIUw==
+"@fluentui/react-card@9.0.0-beta.5":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-card/-/react-card-9.0.0-beta.5.tgz#06af236c628390adbdcdfcc17d0a835e098b3c61"
+  integrity sha512-zxMpgZ8vtz9Cp55uy1+Q9KEZXu8UDh36WNfwmlN/ONgmAYQKvUsAbfM53Zn1Pn+clro4KH2ZKKhueyC+EPAixg==
   dependencies:
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-tabster" "9.0.0-beta.5"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-components@^9.0.0-alpha.124":
-  version "9.0.0-alpha.124"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-components/-/react-components-9.0.0-alpha.124.tgz#6b3f03937a167e651dbf0194c6cc5d3f5132bf01"
-  integrity sha512-oZGNzsZhC/1roJFIKkAClFLiviBmLlg6u1aaF5AZroEMFDOrEGk7umGHglUnIaFf6T/uNuOv3QoUO7p5hcme8Q==
+"@fluentui/react-components@beta":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-components/-/react-components-9.0.0-beta.5.tgz#f864f3b07422594e1642908fdf7dfe54fdeda8f2"
+  integrity sha512-jWbfJ9psHzaqIGGLC/cbrf0sLX+Gn96W6kFINwhM4Ax20Wi+FHSNETi+ZZxtZ1v+tXoNHPLfQBAdivHXKGwuTw==
   dependencies:
-    "@fluentui/react-accordion" "9.0.0-alpha.90"
-    "@fluentui/react-avatar" "9.0.0-alpha.93"
-    "@fluentui/react-badge" "9.0.0-alpha.92"
-    "@fluentui/react-button" "9.0.0-alpha.101"
-    "@fluentui/react-card" "9.0.0-alpha.18"
-    "@fluentui/react-divider" "9.0.0-alpha.79"
-    "@fluentui/react-image" "9.0.0-alpha.90"
-    "@fluentui/react-label" "9.0.0-alpha.51"
-    "@fluentui/react-link" "9.0.0-alpha.95"
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-menu" "9.0.0-alpha.92"
-    "@fluentui/react-popover" "9.0.0-alpha.56"
-    "@fluentui/react-portal" "9.0.0-alpha.61"
-    "@fluentui/react-provider" "9.0.0-alpha.90"
-    "@fluentui/react-text" "9.0.0-alpha.27"
-    "@fluentui/react-theme" "9.0.0-alpha.26"
-    "@fluentui/react-tooltip" "9.0.0-alpha.96"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-accordion" "9.0.0-beta.5"
+    "@fluentui/react-avatar" "9.0.0-beta.4"
+    "@fluentui/react-badge" "9.0.0-beta.4"
+    "@fluentui/react-button" "9.0.0-beta.5"
+    "@fluentui/react-card" "9.0.0-beta.5"
+    "@fluentui/react-divider" "9.0.0-beta.4"
+    "@fluentui/react-image" "9.0.0-beta.4"
+    "@fluentui/react-label" "9.0.0-beta.4"
+    "@fluentui/react-link" "9.0.0-beta.5"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-menu" "9.0.0-beta.5"
+    "@fluentui/react-popover" "9.0.0-beta.5"
+    "@fluentui/react-portal" "9.0.0-beta.5"
+    "@fluentui/react-provider" "9.0.0-beta.5"
+    "@fluentui/react-text" "9.0.0-beta.4"
+    "@fluentui/react-theme" "9.0.0-beta.4"
+    "@fluentui/react-tooltip" "9.0.0-beta.5"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-context-selector@9.0.0-alpha.39":
-  version "9.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-context-selector/-/react-context-selector-9.0.0-alpha.39.tgz#858d7a56dbdbc9fc902f8fb2a02060110aeb9948"
-  integrity sha512-HXC3QMNC/t5sdJoeZYka8k/+MX93voUshRv/ZTbK+uWUWeqfqm1+1Y1IVuQOJjaqKbxtXXXBuGwtJqJuHAwFtw==
+"@fluentui/react-context-selector@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-context-selector/-/react-context-selector-9.0.0-beta.4.tgz#60e634bc2fd528c593125c7bbd58bd8c8812fd73"
+  integrity sha512-DuTi7zBw/CSzKH2DdZ1qdyiCoeeOAQgMTWm8iuDb1RPv9T6ayWf9TQBVLRpgDjvh0EWwe8q8PfnKg2Xi7E2ilQ==
   dependencies:
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     scheduler "^0.20.1"
     tslib "^2.1.0"
 
-"@fluentui/react-divider@9.0.0-alpha.79":
-  version "9.0.0-alpha.79"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-divider/-/react-divider-9.0.0-alpha.79.tgz#f2f657cbc221dcbaa52ad1a628beee6a5d00ef35"
-  integrity sha512-v8EUHi6/H1eMvb/kypc+NgR9BCaxyQ41bpnJeBOJ1qqYgFXy1zruGHrqfOLSc5plaJ4pOUUOeaAqxog2SlQIMQ==
+"@fluentui/react-divider@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-divider/-/react-divider-9.0.0-beta.4.tgz#3264012e25ac20ca6a2d825a11241e07704d312c"
+  integrity sha512-zRKV60jwwsKqShJ3wH6RCLhS86gwIErIHXmS75ES6xsnBCVWbvSl5YS2rWZZnG5MQeO91WsKK07hFcTln/rtKw==
   dependencies:
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-icons@^1.1.140":
-  version "1.1.145"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-1.1.145.tgz#6a0c81a1aa2632c633b8df5f4d27cc97c398ac82"
-  integrity sha512-2zUoUN/Bu9hF5DA/1GkAy1c5D/j9eD8nLnXgU7aF9Q2KdM+gJV4VH9cmsJvHN0d1+Y/Bjv29lKq7fAbpkEBZpA==
+"@fluentui/react-icons@^2.0.152-beta.3":
+  version "2.0.152-beta.3"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-icons/-/react-icons-2.0.152-beta.3.tgz#b1b7c8c2ae131c47a850e792997e46b44604fdd6"
+  integrity sha512-RsNriRJyj+jyhFBqJerFNmRsO1KMBRhxiDPz6eAUSDFsEgaKNKxU+gmS00E9EyV10SxKX15QGQgABF/gofRYFw==
 
-"@fluentui/react-image@9.0.0-alpha.90":
-  version "9.0.0-alpha.90"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-image/-/react-image-9.0.0-alpha.90.tgz#c67d6e66d5b0a1ee998451a768ad1ced9e84f66f"
-  integrity sha512-2/8scANZoj8sRhs6fyg7gFCjT17iP3VoEN+uKywuYPFEpJJHH7YH+65GzaEDyrwubM09IPf/fMiqApPBrz4RNQ==
+"@fluentui/react-image@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-image/-/react-image-9.0.0-beta.4.tgz#4338d81b8a8ece475febb06a4625a68612091384"
+  integrity sha512-/QDAEu1cfUjgiM1QspyeekpuxatwJbW3f2lzqQUqt6nm3QdTMUboy3pquoclLPPAgYOFmIkB/uoiAXGT27F0zw==
   dependencies:
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-label@9.0.0-alpha.51":
-  version "9.0.0-alpha.51"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-label/-/react-label-9.0.0-alpha.51.tgz#6c73049929422e691027752b3b62d5e996c08d0e"
-  integrity sha512-4Hvw0kFNNj1YwZMmvB2p4kwn6Xblc7axmPR1sRyP0ycEcc36rmJK53WfJcCJYHoWpxmpdi00r8SdomFPURCD4w==
+"@fluentui/react-label@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-label/-/react-label-9.0.0-beta.4.tgz#0bdca4a3cd773849329a8eca1c21bd9485991d3d"
+  integrity sha512-VyO/rjvwvXkWsw1t/h02v8AfFtBffPXBeg3AEBZ9ucQ70NwkChcH+QLtzj4aNc4+CluevLsun+qF65wD/Yd5rQ==
   dependencies:
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-link@9.0.0-alpha.95":
-  version "9.0.0-alpha.95"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-link/-/react-link-9.0.0-alpha.95.tgz#bae2042a41e4fa7931dbc1771b6ad5811317bea5"
-  integrity sha512-w3drmeG8jm8pbqcs45yEKTXwnl/F6hDoQOGLKWBcauwEsJ+Xn5Le2ZpVPEaZNYQt3WDJkpaCpQekROtiCHljzQ==
+"@fluentui/react-link@9.0.0-beta.5":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-link/-/react-link-9.0.0-beta.5.tgz#4acc74e9e320a9b5e51794e47120458b0096c0b1"
+  integrity sha512-b1n2DASayqkWbRDJut1Cq5ya2khxJKeo0LD0wiRRHVHzOd/r7AlI0wzeZCeLJpG3Oj80Ro8v69otJkaCnByAbg==
   dependencies:
-    "@fluentui/keyboard-keys" "9.0.0-alpha.5"
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-tabster" "9.0.0-alpha.73"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/keyboard-keys" "9.0.0-beta.1"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-tabster" "9.0.0-beta.5"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-make-styles@9.0.0-alpha.78":
-  version "9.0.0-alpha.78"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-make-styles/-/react-make-styles-9.0.0-alpha.78.tgz#21eb42632ac59164f9482ea304c42b6959752a9c"
-  integrity sha512-CEFZ1ubH6Uhfv1BenZ4j09Rdf8aPLwbS8EnekZUpmUrtOCvmXlh03zyK3FJ22hiMRomaHFNi+blBHdVlULibgQ==
+"@fluentui/react-make-styles@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-make-styles/-/react-make-styles-9.0.0-beta.4.tgz#9e4c086a8768b3199e9434482add3b7465ace62e"
+  integrity sha512-z6yy4xKc8+4YgmsCqluTHNwVyCoG5EuQauIOaeT8kQVvV+vtxTSTqqj9nzG9uknGu29zlwqSzqfI4U5WKEFHyA==
   dependencies:
-    "@fluentui/make-styles" "9.0.0-alpha.35"
-    "@fluentui/react-shared-contexts" "9.0.0-alpha.28"
-    "@fluentui/react-theme" "9.0.0-alpha.26"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/make-styles" "9.0.0-beta.3"
+    "@fluentui/react-shared-contexts" "9.0.0-beta.4"
+    "@fluentui/react-theme" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-menu@9.0.0-alpha.92":
-  version "9.0.0-alpha.92"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-menu/-/react-menu-9.0.0-alpha.92.tgz#5b8767ed21b5bffacb4ef71bc07c3860beb934f7"
-  integrity sha512-RloyLzJy7VSxyyUo8TwsH8hB1NIXEDpHX6nSDrb4z+XHuawTjP5uARgj5IB8twiLLexixK7HJZbvmijBQ+OCqg==
+"@fluentui/react-menu@9.0.0-beta.5":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-menu/-/react-menu-9.0.0-beta.5.tgz#aff36551b03cd09fef925eb7aedebc4fcf354534"
+  integrity sha512-L3cKEtq7LdO2eP+PoH+GNeVIMBJzg24vsti9eP8KNZvcSpl5itUMJdQrjmRvc7Ut2AwKLSawfBv31YZYcMzWtg==
   dependencies:
-    "@fluentui/keyboard-keys" "9.0.0-alpha.5"
-    "@fluentui/react-context-selector" "9.0.0-alpha.39"
-    "@fluentui/react-icons" "^1.1.140"
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-portal" "9.0.0-alpha.61"
-    "@fluentui/react-positioning" "9.0.0-alpha.65"
-    "@fluentui/react-provider" "9.0.0-alpha.90"
-    "@fluentui/react-tabster" "9.0.0-alpha.73"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/keyboard-keys" "9.0.0-beta.1"
+    "@fluentui/react-context-selector" "9.0.0-beta.4"
+    "@fluentui/react-icons" "^2.0.152-beta.3"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-portal" "9.0.0-beta.5"
+    "@fluentui/react-positioning" "9.0.0-beta.4"
+    "@fluentui/react-shared-contexts" "9.0.0-beta.4"
+    "@fluentui/react-tabster" "9.0.0-beta.5"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-popover@9.0.0-alpha.56":
-  version "9.0.0-alpha.56"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-popover/-/react-popover-9.0.0-alpha.56.tgz#a751f2ca8eba18f98914f26fe97f33e658b4cd3e"
-  integrity sha512-BvQY2D/7xiackP32Yqs9Eh9ycHSmZ93VmqZFHViZoAELBL06jhMUiXLMKmFddMjG/gHNSbb6xYJ75mVd/kxiqA==
+"@fluentui/react-popover@9.0.0-beta.5":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-popover/-/react-popover-9.0.0-beta.5.tgz#5b3dc23a28c64d15a8be7b7d60a0d2b96ba1061e"
+  integrity sha512-FWwWrUHy/qB7+zpKKFQC3oOO+6VQvJ0dre8DVgiuC8TKlayykmOka8jFiDgrE9VxSyoR6F3bb0z+/S+7v9JA1w==
   dependencies:
-    "@fluentui/react-context-selector" "9.0.0-alpha.39"
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-portal" "9.0.0-alpha.61"
-    "@fluentui/react-positioning" "9.0.0-alpha.65"
-    "@fluentui/react-shared-contexts" "9.0.0-alpha.28"
-    "@fluentui/react-tabster" "9.0.0-alpha.73"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-context-selector" "9.0.0-beta.4"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-portal" "9.0.0-beta.5"
+    "@fluentui/react-positioning" "9.0.0-beta.4"
+    "@fluentui/react-shared-contexts" "9.0.0-beta.4"
+    "@fluentui/react-tabster" "9.0.0-beta.5"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-portal@9.0.0-alpha.61":
-  version "9.0.0-alpha.61"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-portal/-/react-portal-9.0.0-alpha.61.tgz#4aaf1d92a8f09281e5c9970c361c89b4cdaf83f1"
-  integrity sha512-rXkIUzNtHdbSMFDYWfp57DSBF7QZbAL9eKpw2TVJreJTnlFC+6P1q5HcFyDPHl4GIljo2kErgbPkJsuUN8HxUw==
+"@fluentui/react-portal@9.0.0-beta.5":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-portal/-/react-portal-9.0.0-beta.5.tgz#b12b0460f9f2097bc28162963774a80ec90ff9fe"
+  integrity sha512-xcsOjrUHDBLw1Vw+E8AyPKPxtQONKfBmHPxpA687p5FPC9ZmnfbKxBmm3TxVTaoduc2WezZ5X5/sI2S9IuFsrw==
   dependencies:
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-shared-contexts" "9.0.0-alpha.28"
-    "@fluentui/react-tabster" "9.0.0-alpha.73"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-shared-contexts" "9.0.0-beta.4"
+    "@fluentui/react-tabster" "9.0.0-beta.5"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-positioning@9.0.0-alpha.65":
-  version "9.0.0-alpha.65"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-positioning/-/react-positioning-9.0.0-alpha.65.tgz#d6b48472368913831635e0ddb3ec95b9f4998cac"
-  integrity sha512-rChQlRZFVYEkLwNOc9mMscUWL2LNCCSxTjxwmaKOOml0XVm6Qwd1ify8SvYjmXElvEsseO51f+73LyxsaGIwhQ==
+"@fluentui/react-positioning@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-positioning/-/react-positioning-9.0.0-beta.4.tgz#20ddb15fa18af33392545f96c2d93d4a1475954a"
+  integrity sha512-Exmw9I3A4Qjz5l2cOhwRlY0wQ/WO31GDYB0qJ2UA+46X4d5y46Hp954RthteQZCntM+XFNr8Zp4pinFOGp+rYA==
   dependencies:
-    "@fluentui/react-shared-contexts" "9.0.0-alpha.28"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-shared-contexts" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     "@popperjs/core" "~2.4.3"
     tslib "^2.1.0"
 
-"@fluentui/react-provider@9.0.0-alpha.90":
-  version "9.0.0-alpha.90"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-provider/-/react-provider-9.0.0-alpha.90.tgz#b8d521b6c458f4c18a82151dfd5283391be1003e"
-  integrity sha512-YqFqY1huiBTaSnkTNvssUU4/y0+KTsQ4aQcYaZAc/jNhbBu90Qewrw1aA/DD9eSM0Gi+3H59uK2kVXLAqtepPA==
+"@fluentui/react-provider@9.0.0-beta.5":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-provider/-/react-provider-9.0.0-beta.5.tgz#4fd7cbba629c4104bfb285d73379d70e4c1db0e4"
+  integrity sha512-kYKWD2dK263eFXPV83p3tTl7lVdNl+JY4LCXfPk4o5Bj1p30QXPTpqVzrOsJRovaGsWzFXz2bodi3S+6vGIySQ==
   dependencies:
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-shared-contexts" "9.0.0-alpha.28"
-    "@fluentui/react-tabster" "9.0.0-alpha.73"
-    "@fluentui/react-theme" "9.0.0-alpha.26"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-shared-contexts" "9.0.0-beta.4"
+    "@fluentui/react-tabster" "9.0.0-beta.5"
+    "@fluentui/react-theme" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-shared-contexts@9.0.0-alpha.28":
-  version "9.0.0-alpha.28"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-shared-contexts/-/react-shared-contexts-9.0.0-alpha.28.tgz#25284dfbeec1358fca9121e0d60a9446fd8895c4"
-  integrity sha512-4CSDf+Lwzx7ThPlNlg50TRSFjOqVqOdFFMq6bCJD4s+PDkdlqVR4c41bwtQcNX5M09lthpCmiD6y0QIF7ZNQrw==
+"@fluentui/react-shared-contexts@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-shared-contexts/-/react-shared-contexts-9.0.0-beta.4.tgz#18556451045fa800a90291164d7082fd7ccabe95"
+  integrity sha512-I4Wb0KHQfDAdWMXb+Af8LvmEvsnzMZ4Oky0ubxNTlueALSdwUE4mVj7dKEasCNESdxR0wXm8YooWh1xCX9WG7w==
   dependencies:
-    "@fluentui/react-theme" "9.0.0-alpha.26"
+    "@fluentui/react-theme" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-tabster@9.0.0-alpha.73":
-  version "9.0.0-alpha.73"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tabster/-/react-tabster-9.0.0-alpha.73.tgz#45aa5903f1e5c183b720a3f7a5bba38f04153c93"
-  integrity sha512-m4q2GdoX5Q3MrCsnI+CwKNdoNeKbt4x3iJjmlnQf1OV8ZuzZIh56FvQ9W20spP3Dt4s3/2HDykcZHyPEpaNsOA==
+"@fluentui/react-tabster@9.0.0-beta.5":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tabster/-/react-tabster-9.0.0-beta.5.tgz#e17dde20c8e1a48fed9902347e3e293208ff3155"
+  integrity sha512-35ZfuQwl7QLuFAMcrAftXl39w4BAJCqG6n4V47nVI7DaNNmUaJoP7NfWRKZrHEsfoBkrsbUPt/m0MKE5K2xosw==
   dependencies:
-    "@fluentui/make-styles" "9.0.0-alpha.35"
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-shared-contexts" "9.0.0-alpha.28"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
-    keyborg "^1.0.0"
-    tabster "^1.0.0"
+    "@fluentui/make-styles" "9.0.0-beta.3"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-shared-contexts" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
+    keyborg "^1.0.7"
+    tabster "^1.0.7"
     tslib "^2.1.0"
 
-"@fluentui/react-text@9.0.0-alpha.27":
-  version "9.0.0-alpha.27"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-text/-/react-text-9.0.0-alpha.27.tgz#f0fe36890a8fb51b3039bb946f234ebae70df11c"
-  integrity sha512-0JIFNp4HFzNH9oH/XH3GjrWEcSeJIqf/x+Aguk/dNtTS0z5dy+aII6dyu16/A/Qg25x0gUvOPUardIKYm6meLQ==
+"@fluentui/react-text@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-text/-/react-text-9.0.0-beta.4.tgz#314e16ae5701b300f7df04a19a0b2efe76435111"
+  integrity sha512-GWiD58XtoLMOcjTiyGmhf0dXRdkfx6smUHmlIEqJhSFhGZfwWrqFdxywFRacMUJCJwt9slVFmolZSt43bZ526A==
   dependencies:
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-theme@9.0.0-alpha.26":
-  version "9.0.0-alpha.26"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-theme/-/react-theme-9.0.0-alpha.26.tgz#b74cbfa2222573d64b8e3836dc9b617be00f612c"
-  integrity sha512-T31KCGF6hLRkbMh4kFBNDUVo69hV31oZP4AOM/9nx/Obiefp3po8mC621Zt2hO0AF67BuJMBD14mMhmf1P5XLw==
+"@fluentui/react-theme@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-theme/-/react-theme-9.0.0-beta.4.tgz#6a0603b9934cb26b04c8fdad5b6e0c44c46e80f7"
+  integrity sha512-dfmfZFgb03d43ZguIKbQIGuKEhyYUDNJLheLLV/1CdzZWHxayxEpHofILc6S7L7KVDIhZPniOSjgxmn+R3kzuw==
   dependencies:
     tslib "^2.1.0"
 
-"@fluentui/react-tooltip@9.0.0-alpha.96":
-  version "9.0.0-alpha.96"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tooltip/-/react-tooltip-9.0.0-alpha.96.tgz#9c562bae83ead6e72b68a65af7dc8dae989c0fc0"
-  integrity sha512-xkujaftJ71fi002WT3hgEd+l5C/utTyEDtgZ3azu3LZj20vRvHiDoSA8ilMYT3vjajaIv0C3UYG+RBBhFu196A==
+"@fluentui/react-tooltip@9.0.0-beta.5":
+  version "9.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tooltip/-/react-tooltip-9.0.0-beta.5.tgz#7b7a628d4a2546c5a860805c8e67c66b8e44d05e"
+  integrity sha512-18uQHPtnioFqBu9IF428hj2YCmeIIV/xqnrt9NdzBp1RIgG5B3uk+2Trm3l2cw/adbG9y/a9/nWiTlLSbdNrmw==
   dependencies:
-    "@fluentui/react-make-styles" "9.0.0-alpha.78"
-    "@fluentui/react-portal" "9.0.0-alpha.61"
-    "@fluentui/react-positioning" "9.0.0-alpha.65"
-    "@fluentui/react-shared-contexts" "9.0.0-alpha.28"
-    "@fluentui/react-theme" "9.0.0-alpha.26"
-    "@fluentui/react-utilities" "9.0.0-alpha.56"
+    "@fluentui/react-make-styles" "9.0.0-beta.4"
+    "@fluentui/react-portal" "9.0.0-beta.5"
+    "@fluentui/react-positioning" "9.0.0-beta.4"
+    "@fluentui/react-shared-contexts" "9.0.0-beta.4"
+    "@fluentui/react-theme" "9.0.0-beta.4"
+    "@fluentui/react-utilities" "9.0.0-beta.4"
     tslib "^2.1.0"
 
-"@fluentui/react-utilities@9.0.0-alpha.56":
-  version "9.0.0-alpha.56"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-utilities/-/react-utilities-9.0.0-alpha.56.tgz#d6b195e0c08732e3d90124aa49728e980802a3af"
-  integrity sha512-fjXfR9vG8SFHQbyLNwpIUXc9H6m/nKgxLEYcZq1v/WzG19+tD3dK+rp5egxeEigH0G43+fNG8fsB1Bw/yfTqbA==
+"@fluentui/react-utilities@9.0.0-beta.4":
+  version "9.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-utilities/-/react-utilities-9.0.0-beta.4.tgz#719204ebe4a231091c2bff7a10397c8bd76f0538"
+  integrity sha512-b5drXcG02SNHokC39/B19dt1cti0ErtyS94ymMl1ppZ/Lh02/3VYukYsTBXBpKim4zmALAxqGkx/yXm95A7UBQ==
   dependencies:
-    "@fluentui/keyboard-keys" "9.0.0-alpha.5"
+    "@fluentui/keyboard-keys" "9.0.0-beta.1"
     tslib "^2.1.0"
 
 "@gar/promisify@^1.0.1":
@@ -4761,10 +4764,15 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-csstype@^2.5.7, csstype@^2.6.7:
+csstype@^2.5.7:
   version "2.6.18"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.18.tgz#980a8b53085f34af313410af064f2bd241784218"
   integrity sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ==
+
+csstype@^2.6.7:
+  version "2.6.19"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.19.tgz#feeb5aae89020bb389e1f63669a5ed490e391caa"
+  integrity sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==
 
 csstype@^3.0.2:
   version "3.0.9"
@@ -7465,10 +7473,10 @@ junk@^3.1.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.1.0.tgz#31499098d902b7e98c5d9b9c80f43457a88abfa1"
   integrity sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
 
-keyborg@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-1.0.0.tgz#2c1bd78a1d5b9357345f6cd3c1b661c21303f56e"
-  integrity sha512-kOY0HEqlIRO3qZ96j325JU/KGJz2tlRakK4h/RxCjG6c6Rf/T40vQ73cui090KYz1SCpUnWUqsCIx/SCVYW2LQ==
+keyborg@^1.0.7, keyborg@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/keyborg/-/keyborg-1.1.0.tgz#f6886a90b4ec1f4c5272326213110f6d9e831d0e"
+  integrity sha512-AmEH/if+1TG1MkDT4UOAG8ZKTTO2IwJBXq20crsLD3QhMsRivL6OpxZSTBrnbGAsn/QeH/+YIgDCXcNvLSe/Yw==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -9801,10 +9809,10 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-rtl-css-js@^1.14.1:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.14.2.tgz#fb2168433af9cdabee8a1613f4e2cbd1148acf6f"
-  integrity sha512-t6Wc/wpqm8s3kuXAV6tL/T7VS6n0XszzX58CgCsLj3O2xi9ITSLfzYhtl+GKyxCi/3QEqVctOJQwCiDzb2vteQ==
+rtl-css-js@^1.14.5:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.15.0.tgz#680ed816e570a9ebccba9e1cd0f202c6a8bb2dc0"
+  integrity sha512-99Cu4wNNIhrI10xxUaABHsdDqzalrSRTie4GeCmbGVuehm4oj+fIy8fTzB+16pmKe8Bv9rl+hxIBez6KxExTew==
   dependencies:
     "@babel/runtime" "^7.1.2"
 
@@ -10564,9 +10572,9 @@ style-to-object@0.3.0, style-to-object@^0.3.0:
     inline-style-parser "0.1.1"
 
 stylis@^4.0.6:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
-  integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
+  integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
 
 supports-color@8.1.1:
   version "8.1.1"
@@ -10621,12 +10629,13 @@ table@^6.0.9:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
 
-tabster@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/tabster/-/tabster-1.0.4.tgz#1e5f0e1f0c92459b239e72f6c21f72003da51420"
-  integrity sha512-N/XQVfIYB4GIxFxK1VOftCxh6Jvojce36tgV7nDAQ2P+WXYpL8sTn4uUoQ13Urf+knCOnoKmreKwteqa+m5OTw==
+tabster@^1.0.7:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tabster/-/tabster-1.1.1.tgz#010dce319edb2a2671af2e7e862008d0c442dd7a"
+  integrity sha512-h8PPDMHeT9Np/MLqijfZAaWgn/Y0okz9mLu+f0aRMX+534oM5NA45ySrQ1oeORpCPRawbcjCwdmTHq4C0xJhCw==
   dependencies:
-    keyborg "^1.0.0"
+    keyborg "^1.1.0"
+    tslib "^2.3.1"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
@@ -10894,7 +10903,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
This PR adds:

- the `Dashboard` block as an exemplar of `Layout`
- a `DescriptionList` block
- a smaller variant for the Tabs component
- missing stories and tests

We're still blocked by v9's Dialog component (status was in development as of this PR), so this won't include the flow that facilitates end-users hiding/showing Dashboard items.

As for other implementation tasks in the designs, this does not include any features that don't already have parity in `react-teams`, e.g. drag and drop placement, map chart card content, table card content.